### PR TITLE
bugfix: Restore wildcard splats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+*.auto.tfvars.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,5 +3,7 @@ repos:
     rev: v0.1.23
     hooks:
       - id: tflint
+        args:
+          - '--disable-rule=terraform_deprecated_index'
       - id: terraform-validate
       - id: terraform-fmt

--- a/customer-managed/aws/terraform/iam_redpanda_agent.tf
+++ b/customer-managed/aws/terraform/iam_redpanda_agent.tf
@@ -254,7 +254,7 @@ data "aws_iam_policy_document" "redpanda_agent1" {
 
         "arn:aws:ec2:*::image/*",
       ],
-    aws_subnet.private[*].arn)
+    aws_subnet.private.*.arn)
   }
 
   statement {

--- a/customer-managed/aws/terraform/iam_rpk_user.tf
+++ b/customer-managed/aws/terraform/iam_rpk_user.tf
@@ -95,7 +95,7 @@ data "aws_iam_policy_document" "byovpc_rpk_user_1" {
     actions = [
       "ec2:DescribeSubnets",
     ]
-    resources = concat(tolist(aws_subnet.public[*].arn), tolist(aws_subnet.private[*].arn))
+    resources = concat(tolist(aws_subnet.public.*.arn), tolist(aws_subnet.private.*.arn))
   }
 
   statement {
@@ -330,7 +330,7 @@ data "aws_iam_policy_document" "byovpc_rpk_user_2" {
     actions = [
       "ec2:RunInstances",
     ]
-    resources = concat([aws_security_group.redpanda_agent.arn], tolist(aws_subnet.public[*].arn), tolist(aws_subnet.private[*].arn))
+    resources = concat([aws_security_group.redpanda_agent.arn], tolist(aws_subnet.public.*.arn), tolist(aws_subnet.private.*.arn))
   }
 
   statement {

--- a/customer-managed/aws/terraform/nat.tf
+++ b/customer-managed/aws/terraform/nat.tf
@@ -8,7 +8,7 @@ resource "aws_internet_gateway" "redpanda" {
 
 resource "aws_nat_gateway" "redpanda" {
   allocation_id = aws_eip.nat_gateway.id
-  subnet_id     = aws_subnet.public[*].id[0]
+  subnet_id     = aws_subnet.public[0].id
   depends_on = [
     aws_internet_gateway.redpanda,
   ]
@@ -16,9 +16,9 @@ resource "aws_nat_gateway" "redpanda" {
 
 resource "aws_route" "nat" {
   count                  = length(var.private_subnet_cidrs)
-  route_table_id         = aws_route_table.private[*].id[count.index]
+  route_table_id         = aws_route_table.private.*.id[count.index]
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = element(aws_nat_gateway.redpanda[*].id, count.index)
+  nat_gateway_id         = aws_nat_gateway.redpanda.id
 }
 
 resource "aws_route" "public" {

--- a/customer-managed/aws/terraform/outputs.tf
+++ b/customer-managed/aws/terraform/outputs.tf
@@ -51,12 +51,12 @@ output "vpc_arn" {
 }
 
 output "public_subnet_ids" {
-  value       = jsonencode(aws_subnet.public[*].arn)
+  value       = jsonencode(aws_subnet.public.*.arn)
   description = "Public subnets IDs created"
 }
 
 output "private_subnet_ids" {
-  value       = jsonencode(aws_subnet.private[*].arn)
+  value       = jsonencode(aws_subnet.private.*.arn)
   description = "Private subnet IDs created"
 }
 
@@ -91,6 +91,6 @@ output "node_security_group_arn" {
 }
 
 output "byovpc_rpk_user_policy_arns" {
-  value       = values(aws_iam_policy.byovpc_rpk_user)[*].arn
+  value       = jsonencode(values(aws_iam_policy.byovpc_rpk_user).*.arn)
   description = "ARNs of policies associated with the 'rpk user'. Can be used by Redpanda engineers to the assume the role and test provisioning with more limited access."
 }

--- a/customer-managed/aws/terraform/routing.tf
+++ b/customer-managed/aws/terraform/routing.tf
@@ -21,21 +21,21 @@ resource "aws_main_route_table_association" "vpc-main-route-table" {
 
 resource "aws_route_table_association" "public" {
   count          = length(var.public_subnet_cidrs)
-  subnet_id      = aws_subnet.public[*].id[count.index]
+  subnet_id      = aws_subnet.public[count.index].id
   route_table_id = aws_route_table.main.id
 }
 
 resource "aws_route_table_association" "private" {
   count          = length(var.private_subnet_cidrs)
-  subnet_id      = aws_subnet.private[*].id[count.index]
-  route_table_id = aws_route_table.private[*].id[count.index]
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
 }
 
 # Routes S3 traffic to the local gateway endpoint
 resource "aws_vpc_endpoint_route_table_association" "private_s3" {
   count           = length(var.private_subnet_cidrs)
   vpc_endpoint_id = aws_vpc_endpoint.s3.id
-  route_table_id  = aws_route_table.private[*].id[count.index]
+  route_table_id  = aws_route_table.private[count.index].id
 }
 
 resource "aws_vpc_endpoint_route_table_association" "public_s3" {


### PR DESCRIPTION
The version of terraform being used by the certification tests does not support the syntax the way it is currently on main. I need to modify it to use `.*.` syntax which works perfectly fine, but does trigger some tflint warnings which we now need to exclude.