### PR TITLE
Add support for 'ignore_tags' on the AWS provider

### DIFF
--- a/customer-managed/aws/terraform/providers.tf
+++ b/customer-managed/aws/terraform/providers.tf
@@ -16,4 +16,7 @@ provider "aws" {
   default_tags {
     tags = var.default_tags
   }
+  ignore_tags {
+    key_prefixes = var.ignore_tags
+  }
 }

--- a/customer-managed/aws/terraform/variables.tf
+++ b/customer-managed/aws/terraform/variables.tf
@@ -88,6 +88,14 @@ variable "default_tags" {
   HELP
 }
 
+variable "ignore_tags" {
+  type        = list(string)
+  default     = []
+  description = <<-HELP
+  List of tag keys that will be ignored during reconciliation of this terraform
+  HELP
+}
+
 variable "enable_private_link" {
   type        = bool
   default     = false


### PR DESCRIPTION
If there are any tags which are added through automation outside of this terraform, they can be passed into the `ignore_tags` variable so that they will be excluded during terraform apply|plan.

For example, internally at Redpanda we use cloud-nuke to clean up resources in our accounts. The cloud-nuke process adds a tag `cloud-nuke-first-seen` to all resources so that after a configurable amount of time the resource can be deleted. Since those tags are added by another process outside of this terraform we will want to ignore them.