### PR TITLE
Add comments explaining where the cidr blocks are coming from

### DIFF
--- a/customer-managed/aws/terraform/security_groups.tf
+++ b/customer-managed/aws/terraform/security_groups.tf
@@ -64,12 +64,22 @@ resource "aws_security_group" "redpanda_node_group" {
 
 locals {
   rp_node_group_cidr_blocks = var.public_cluster ? [
+
+    // only used in the event that you want a public cluster, when the variable public_cluster is true
     "0.0.0.0/0"
+
     ] : [
+
+    // RFC 6598 reserved prefix for shared address space
+    // https://datatracker.ietf.org/doc/html/rfc6598
     "100.64.0.0/10",
+
+    // RFC 1918 reserved IP address space for private internets
+    // https://datatracker.ietf.org/doc/html/rfc1918
     "172.16.0.0/12",
     "192.168.0.0/16",
     "10.0.0.0/8",
+
   ]
 }
 resource "aws_security_group_rule" "redpanda_node_group" {


### PR DESCRIPTION
Prior to this commit we had a list of cidr blocks that are used for ingress to redpanda, but there was no explanation about where these 'magic' blocks were coming from or what they represent.

Added some comments and included a link to the documentation.