### PR TITLE
byovpc/aws: Fix reference to agent policy name

### DIFF
--- a/customer-managed/aws/terraform/iam_redpanda_agent.tf
+++ b/customer-managed/aws/terraform/iam_redpanda_agent.tf
@@ -337,7 +337,7 @@ data "aws_iam_policy_document" "redpanda_agent2" {
       aws_iam_policy.load_balancer_controller_policy["1"].arn,
       aws_iam_policy.load_balancer_controller_policy["2"].arn,
       # redpanda_agent1 and redpanda_agent2, cannot be referenced by object due to cycle
-      "arn:aws:iam::${local.aws_account_id}:policy/redpanda-agent-*-*",
+      "arn:aws:iam::${local.aws_account_id}:policy/${var.common_prefix}agent-*-*",
       aws_iam_policy.cluster_autoscaler_policy.arn,
       aws_iam_policy.redpanda_cloud_storage_manager.arn,
       aws_iam_policy.connectors_secrets_manager.arn,


### PR DESCRIPTION
Depending on what is used for the variable `common_prefix` this reference to the policy may or may not be accurate. (It works as is only if the default value for `common_prefix` is used.)

If you use something else, e.g. `byovpc-redpanda-` there will be an error like:

```
An error occurred while checking IAM Instance Profiles.
operation error IAM: GetPolicy,
https response error StatusCode: 403,
RequestID: xxx,
api error AccessDenied: User: xxx is not authorized to perform: iam:GetPolicy
on resource: policy arn:aws:iam::xxx:policy/byovpc-redpanda-agent-2-xxx
because no identity-based policy allows the iam:GetPolicy action
```