### PR TITLE
BYOVPC/aws: Remove trailing dash in common-prefix

### DIFF
--- a/customer-managed/aws/terraform/iam_connectors_node_group.tf
+++ b/customer-managed/aws/terraform/iam_connectors_node_group.tf
@@ -10,7 +10,7 @@ data "aws_iam_policy_document" "connectors_node_group_trust" {
 }
 
 resource "aws_iam_role" "connectors_node_group" {
-  name_prefix           = "${var.common_prefix}connect-"
+  name_prefix           = "${var.common_prefix}-connect-"
   path                  = "/"
   force_detach_policies = true
   tags = merge(
@@ -23,7 +23,7 @@ resource "aws_iam_role" "connectors_node_group" {
 }
 
 resource "aws_iam_instance_profile" "connectors_node_group" {
-  name_prefix = "${var.common_prefix}connect-"
+  name_prefix = "${var.common_prefix}-connect-"
   path        = "/"
   role        = aws_iam_role.connectors_node_group.name
   tags = merge(

--- a/customer-managed/aws/terraform/iam_connectors_secrets.tf
+++ b/customer-managed/aws/terraform/iam_connectors_secrets.tf
@@ -32,12 +32,12 @@ data "aws_iam_policy_document" "connectors_secrets_manager_trust" {
 }
 
 resource "aws_iam_role" "connectors_secrets_manager" {
-  name_prefix        = "${var.common_prefix}connectors-scrts-mgr-"
+  name_prefix        = "${var.common_prefix}-connectors-scrts-mgr-"
   assume_role_policy = data.aws_iam_policy_document.connectors_secrets_manager_trust.json
 }
 
 resource "aws_iam_policy" "connectors_secrets_manager" {
-  name_prefix = "${var.common_prefix}connectors-scrts-mgr-"
+  name_prefix = "${var.common_prefix}-connectors-scrts-mgr-"
   path        = "/"
   description = "Redpanda connectors - grant read-only access to connectors/* secrets manager"
   policy      = data.aws_iam_policy_document.connectors_secrets_manager.json

--- a/customer-managed/aws/terraform/iam_redpanda_agent.tf
+++ b/customer-managed/aws/terraform/iam_redpanda_agent.tf
@@ -337,7 +337,7 @@ data "aws_iam_policy_document" "redpanda_agent2" {
       aws_iam_policy.load_balancer_controller_policy["1"].arn,
       aws_iam_policy.load_balancer_controller_policy["2"].arn,
       # redpanda_agent1 and redpanda_agent2, cannot be referenced by object due to cycle
-      "arn:aws:iam::${local.aws_account_id}:policy/${var.common_prefix}agent-*-*",
+      "arn:aws:iam::${local.aws_account_id}:policy/${var.common_prefix}-agent-*-*",
       aws_iam_policy.cluster_autoscaler_policy.arn,
       aws_iam_policy.redpanda_cloud_storage_manager.arn,
       aws_iam_policy.connectors_secrets_manager.arn,
@@ -658,13 +658,13 @@ data "aws_iam_policy_document" "redpanda_agent_trust_ec2" {
 }
 
 resource "aws_iam_role" "redpanda_agent" {
-  name_prefix        = "${var.common_prefix}agent-"
+  name_prefix        = "${var.common_prefix}-agent-"
   path               = "/"
   assume_role_policy = data.aws_iam_policy_document.redpanda_agent_trust_ec2.json
 }
 
 resource "aws_iam_instance_profile" "redpanda_agent" {
-  name_prefix = "${var.common_prefix}agent-"
+  name_prefix = "${var.common_prefix}-agent-"
   role        = aws_iam_role.redpanda_agent.name
 }
 
@@ -673,7 +673,7 @@ resource "aws_iam_policy" "redpanda_agent" {
     "1" = data.aws_iam_policy_document.redpanda_agent1
     "2" = data.aws_iam_policy_document.redpanda_agent2
   }
-  name_prefix = "${var.common_prefix}agent-${each.key}-"
+  name_prefix = "${var.common_prefix}-agent-${each.key}-"
   policy      = each.value.json
 }
 
@@ -688,7 +688,7 @@ resource "aws_iam_role_policy_attachment" "redpanda_agent" {
 
 resource "aws_iam_policy" "redpanda_agent_private_link" {
   count       = var.enable_private_link ? 1 : 0
-  name_prefix = "${var.common_prefix}agent-pl-"
+  name_prefix = "${var.common_prefix}-agent-pl-"
   policy      = data.aws_iam_policy_document.redpanda_agent_private_link[0].json
 }
 

--- a/customer-managed/aws/terraform/iam_redpanda_cloud_storage_manager.tf
+++ b/customer-managed/aws/terraform/iam_redpanda_cloud_storage_manager.tf
@@ -33,12 +33,12 @@ data "aws_iam_policy_document" "redpanda_cloud_storage_manager_trust" {
 }
 
 resource "aws_iam_policy" "redpanda_cloud_storage_manager" {
-  name_prefix = "${var.common_prefix}cloud-storage-manager-"
+  name_prefix = "${var.common_prefix}-cloud-storage-manager-"
   policy      = data.aws_iam_policy_document.redpanda_cloud_storage_manager.json
 }
 
 resource "aws_iam_role" "redpanda_cloud_storage_manager" {
-  name_prefix        = "${var.common_prefix}cloud-storage-manager-"
+  name_prefix        = "${var.common_prefix}-cloud-storage-manager-"
   assume_role_policy = data.aws_iam_policy_document.redpanda_cloud_storage_manager_trust.json
 }
 

--- a/customer-managed/aws/terraform/iam_redpanda_cluster.tf
+++ b/customer-managed/aws/terraform/iam_redpanda_cluster.tf
@@ -15,7 +15,7 @@ resource "aws_iam_role" "k8s_cluster" {
   assume_role_policy    = data.aws_iam_policy_document.k8s_cluster_trust.json
   force_detach_policies = true
   max_session_duration  = 3600
-  name_prefix           = "${var.common_prefix}cluster-"
+  name_prefix           = "${var.common_prefix}-cluster-"
   path                  = "/"
 }
 

--- a/customer-managed/aws/terraform/iam_redpanda_console.tf
+++ b/customer-managed/aws/terraform/iam_redpanda_console.tf
@@ -29,7 +29,7 @@ data "aws_iam_policy_document" "console_secrets_manager" {
 }
 
 resource "aws_iam_policy" "console_secrets_manager" {
-  name_prefix = "${var.common_prefix}console-scrts-mgr-"
+  name_prefix = "${var.common_prefix}-console-scrts-mgr-"
   path        = "/"
   description = "Redpanda console - grant create/update/delete access to secrets manager"
   policy      = data.aws_iam_policy_document.console_secrets_manager.json
@@ -57,7 +57,7 @@ data "aws_iam_policy_document" "console_secrets_manager_trust" {
 }
 
 resource "aws_iam_role" "console_secrets_manager_redpanda" {
-  name_prefix        = "${var.common_prefix}console-scrts-mgr-"
+  name_prefix        = "${var.common_prefix}-console-scrts-mgr-"
   assume_role_policy = data.aws_iam_policy_document.console_secrets_manager_trust.json
 }
 

--- a/customer-managed/aws/terraform/iam_redpanda_node_group.tf
+++ b/customer-managed/aws/terraform/iam_redpanda_node_group.tf
@@ -14,12 +14,12 @@ data "aws_iam_policy_document" "redpanda_node_group_trust" {
 resource "aws_iam_role" "redpanda_node_group" {
   assume_role_policy    = data.aws_iam_policy_document.redpanda_node_group_trust.json
   force_detach_policies = true
-  name_prefix           = "${var.common_prefix}rp-"
+  name_prefix           = "${var.common_prefix}-rp-"
   path                  = "/"
 }
 
 resource "aws_iam_instance_profile" "redpanda_node_group" {
-  name_prefix = "${var.common_prefix}rp-"
+  name_prefix = "${var.common_prefix}-rp-"
   path        = "/"
   role        = aws_iam_role.redpanda_node_group.name
 }

--- a/customer-managed/aws/terraform/iam_rpk_user.tf
+++ b/customer-managed/aws/terraform/iam_rpk_user.tf
@@ -150,7 +150,7 @@ data "aws_iam_policy_document" "byovpc_rpk_user_1" {
       aws_iam_role.k8s_cluster.arn,
       aws_iam_role.redpanda_utility_node_group.arn,
       aws_iam_role.connectors_node_group.arn,
-      "arn:aws:iam::${local.aws_account_id}:role/${var.common_prefix}rpk-user-role-*",
+      "arn:aws:iam::${local.aws_account_id}:role/${var.common_prefix}-rpk-user-role-*",
     ]
   }
 
@@ -363,7 +363,7 @@ resource "aws_iam_policy" "byovpc_rpk_user" {
     "1" = data.aws_iam_policy_document.byovpc_rpk_user_1,
     "2" = data.aws_iam_policy_document.byovpc_rpk_user_2,
   }
-  name_prefix = "${var.common_prefix}rpk-user-${each.key}_"
+  name_prefix = "${var.common_prefix}-rpk-user-${each.key}_"
   path        = "/"
   description = "Minimum permissions required for RPK user for BYO VPC"
   policy      = each.value.json

--- a/customer-managed/aws/terraform/iam_utility_node_group.tf
+++ b/customer-managed/aws/terraform/iam_utility_node_group.tf
@@ -40,7 +40,7 @@ data "aws_iam_policy_document" "cluster_autoscaler_policy" {
 }
 
 resource "aws_iam_policy" "cluster_autoscaler_policy" {
-  name_prefix = "${var.common_prefix}rp-autoscaler-"
+  name_prefix = "${var.common_prefix}-rp-autoscaler-"
   policy      = data.aws_iam_policy_document.cluster_autoscaler_policy.json
 }
 
@@ -70,7 +70,7 @@ data "aws_iam_policy_document" "external_dns" {
 }
 
 resource "aws_iam_policy" "external_dns_policy" {
-  name_prefix = "${var.common_prefix}external_dns_policy-"
+  name_prefix = "${var.common_prefix}-external_dns_policy-"
   path        = "/"
   description = "Policy to enable external-dns to manage hosted zones"
   policy      = data.aws_iam_policy_document.external_dns.json
@@ -189,7 +189,7 @@ data "aws_iam_policy_document" "aws_ebs_csi_driver" {
 }
 
 resource "aws_iam_policy" "aws_ebs_csi_driver_policy" {
-  name_prefix = "${var.common_prefix}aws_ebs_csi_driver-"
+  name_prefix = "${var.common_prefix}-aws_ebs_csi_driver-"
   path        = "/"
   description = "Policy to enable EKS nodes to manage and create EBS volumes using the AWS EBS CSI driver"
 
@@ -596,7 +596,7 @@ resource "aws_iam_policy" "load_balancer_controller_policy" {
     "1" : data.aws_iam_policy_document.load_balancer_controller_1
     "2" : data.aws_iam_policy_document.load_balancer_controller_2
   }
-  name_prefix = "${var.common_prefix}load_balancer_controller_${each.key}-"
+  name_prefix = "${var.common_prefix}-load_balancer_controller_${each.key}-"
   path        = "/"
   description = "Policy to enable the load balancer controller to expose load balancers"
   policy      = each.value.json
@@ -638,7 +638,7 @@ data "aws_iam_policy_document" "cert_manager" {
 }
 
 resource "aws_iam_policy" "cert_manager" {
-  name_prefix = "${var.common_prefix}cert_manager_policy-"
+  name_prefix = "${var.common_prefix}-cert_manager_policy-"
   path        = "/"
   description = "Policy to enable cert-manager to manage challenges"
   policy      = data.aws_iam_policy_document.cert_manager.json
@@ -662,7 +662,7 @@ data "aws_iam_policy_document" "utility_node_group_trust" {
 resource "aws_iam_role" "redpanda_utility_node_group" {
   assume_role_policy    = data.aws_iam_policy_document.utility_node_group_trust.json
   force_detach_policies = true
-  name_prefix           = "${var.common_prefix}util-"
+  name_prefix           = "${var.common_prefix}-util-"
   path                  = "/"
 }
 
@@ -684,7 +684,7 @@ resource "aws_iam_role_policy_attachment" "external_dns_utility_nodes" {
 }
 
 resource "aws_iam_instance_profile" "utility" {
-  name_prefix = "${var.common_prefix}util-"
+  name_prefix = "${var.common_prefix}-util-"
   path        = "/"
   role        = aws_iam_role.redpanda_utility_node_group.name
 }

--- a/customer-managed/aws/terraform/security_groups.tf
+++ b/customer-managed/aws/terraform/security_groups.tf
@@ -2,7 +2,7 @@
 // Redpanda Agent security group
 // -----------------------------
 resource "aws_security_group" "redpanda_agent" {
-  name_prefix = "${var.common_prefix}agent-"
+  name_prefix = "${var.common_prefix}-agent-"
   description = "Redpanda agent VM"
   vpc_id      = aws_vpc.redpanda.id
   ingress     = []
@@ -22,7 +22,7 @@ resource "aws_security_group" "redpanda_agent" {
 // Connectors security group
 // -----------------------------
 resource "aws_security_group" "connectors" {
-  name_prefix = "${var.common_prefix}connect-"
+  name_prefix = "${var.common_prefix}-connect-"
   description = "Redpanda connectors nodes"
   vpc_id      = aws_vpc.redpanda.id
   lifecycle {
@@ -44,7 +44,7 @@ resource "aws_security_group_rule" "connectors" {
 // Utility security group
 // -----------------------------
 resource "aws_security_group" "utility" {
-  name_prefix = "${var.common_prefix}util-"
+  name_prefix = "${var.common_prefix}-util-"
   description = "Redpanda utility nodes"
   vpc_id      = aws_vpc.redpanda.id
   lifecycle {
@@ -66,7 +66,7 @@ resource "aws_security_group_rule" "utility" {
 // Redpanda Node Group security group
 // ----------------------------------
 resource "aws_security_group" "redpanda_node_group" {
-  name_prefix = "${var.common_prefix}rp-"
+  name_prefix = "${var.common_prefix}-rp-"
   description = "Redpanda cluster nodes"
   vpc_id      = aws_vpc.redpanda.id
   lifecycle {
@@ -108,7 +108,7 @@ resource "aws_security_group_rule" "redpanda_node_group" {
 // Cluster security group
 // -----------------------------
 resource "aws_security_group" "cluster" {
-  name_prefix = "${var.common_prefix}cluster-"
+  name_prefix = "${var.common_prefix}-cluster-"
   description = "EKS cluster security group"
   vpc_id      = aws_vpc.redpanda.id
   lifecycle {
@@ -160,7 +160,7 @@ resource "aws_security_group_rule" "cluster_egress_nodes_kubelet" {
 // Node security group
 // -----------------------------
 resource "aws_security_group" "node" {
-  name_prefix = "${var.common_prefix}node-"
+  name_prefix = "${var.common_prefix}-node-"
   description = "EKS node shared security group"
   vpc_id      = aws_vpc.redpanda.id
   lifecycle {

--- a/customer-managed/aws/terraform/variables.tf
+++ b/customer-managed/aws/terraform/variables.tf
@@ -106,7 +106,7 @@ variable "enable_private_link" {
 
 variable "common_prefix" {
   type        = string
-  default     = "redpanda-"
+  default     = "redpanda"
   description = <<-HELP
   Text to be included at the start of the name prefix on any objects supporting name prefixes.
   HELP


### PR DESCRIPTION
I confirmed that this change results in a no-op if the provided variable is updated to remove the trailing dash and this code is used.

Addresses feedback in this pr:
https://github.com/redpanda-data/cloud-examples/pull/10#discussion_r1695752352