### PR TITLE
Make RPK user, VPC and related objects optional

### DIFF
--- a/customer-managed/aws/terraform/iam_redpanda_agent.tf
+++ b/customer-managed/aws/terraform/iam_redpanda_agent.tf
@@ -96,7 +96,7 @@ data "aws_iam_policy_document" "redpanda_agent1" {
       "ec2:DescribeVpcAttribute",
     ]
     resources = [
-      aws_vpc.redpanda.arn
+      data.aws_vpc.redpanda.arn
     ]
   }
 

--- a/customer-managed/aws/terraform/iam_rpk_user.tf
+++ b/customer-managed/aws/terraform/iam_rpk_user.tf
@@ -11,6 +11,7 @@
 # So that these validations may be performed certain read actions are also suggested for the RPK User.
 
 data "aws_iam_policy_document" "byovpc_rpk_user_1" {
+  count = var.create_rpk_user ? 1 : 0
   statement {
     effect = "Allow"
     actions = [
@@ -86,7 +87,7 @@ data "aws_iam_policy_document" "byovpc_rpk_user_1" {
       "ec2:DescribeVpcAttribute",
     ]
     resources = [
-      aws_vpc.redpanda.arn
+      data.aws_vpc.redpanda.arn
     ]
   }
 
@@ -248,6 +249,7 @@ data "aws_iam_policy_document" "byovpc_rpk_user_1" {
 }
 
 data "aws_iam_policy_document" "byovpc_rpk_user_2" {
+  count = var.create_rpk_user ? 1 : 0
   statement {
     effect = "Allow"
     actions = [
@@ -359,13 +361,18 @@ data "aws_iam_policy_document" "byovpc_rpk_user_2" {
   }
 }
 
-resource "aws_iam_policy" "byovpc_rpk_user" {
-  for_each = {
-    "1" = data.aws_iam_policy_document.byovpc_rpk_user_1,
-    "2" = data.aws_iam_policy_document.byovpc_rpk_user_2,
-  }
-  name_prefix = "${var.common_prefix}-rpk-user-${each.key}_"
+resource "aws_iam_policy" "byovpc_rpk_user_1" {
+  count       = var.create_rpk_user ? 1 : 0
+  name_prefix = "${var.common_prefix}-rpk-user-1_"
   path        = "/"
   description = "Minimum permissions required for RPK user for BYO VPC"
-  policy      = each.value.json
+  policy      = data.aws_iam_policy_document.byovpc_rpk_user_1[0].json
+}
+
+resource "aws_iam_policy" "byovpc_rpk_user_2" {
+  count       = var.create_rpk_user ? 1 : 0
+  name_prefix = "${var.common_prefix}-rpk-user-2_"
+  path        = "/"
+  description = "Minimum permissions required for RPK user for BYO VPC"
+  policy      = data.aws_iam_policy_document.byovpc_rpk_user_2[0].json
 }

--- a/customer-managed/aws/terraform/iam_utility_node_group.tf
+++ b/customer-managed/aws/terraform/iam_utility_node_group.tf
@@ -330,7 +330,7 @@ data "aws_iam_policy_document" "load_balancer_controller_1" {
     condition {
       test     = "ArnEquals"
       variable = "ec2:Vpc"
-      values   = [aws_vpc.redpanda.arn]
+      values   = [data.aws_vpc.redpanda.arn]
     }
   }
 

--- a/customer-managed/aws/terraform/outputs.tf
+++ b/customer-managed/aws/terraform/outputs.tf
@@ -47,7 +47,7 @@ output "dynamodb_table_arn" {
 }
 
 output "vpc_arn" {
-  value = aws_vpc.redpanda.arn
+  value = data.aws_vpc.redpanda.arn
 }
 
 output "public_subnet_ids" {
@@ -91,7 +91,7 @@ output "node_security_group_arn" {
 }
 
 output "byovpc_rpk_user_policy_arns" {
-  value       = jsonencode(values(aws_iam_policy.byovpc_rpk_user).*.arn)
+  value       = var.create_rpk_user ? jsonencode([aws_iam_policy.byovpc_rpk_user_1[0].arn, aws_iam_policy.byovpc_rpk_user_2[0].arn]) : jsonencode([])
   description = "ARNs of policies associated with the 'rpk user'. Can be used by Redpanda engineers to the assume the role and test provisioning with more limited access."
 }
 

--- a/customer-managed/aws/terraform/routing.tf
+++ b/customer-managed/aws/terraform/routing.tf
@@ -1,10 +1,10 @@
 resource "aws_route_table" "main" {
-  vpc_id = aws_vpc.redpanda.id
+  vpc_id = data.aws_vpc.redpanda.id
 }
 
 resource "aws_route_table" "private" {
   count  = length(var.private_subnet_cidrs)
-  vpc_id = aws_vpc.redpanda.id
+  vpc_id = data.aws_vpc.redpanda.id
 
   tags = merge(
     var.default_tags,
@@ -15,7 +15,7 @@ resource "aws_route_table" "private" {
 }
 
 resource "aws_main_route_table_association" "vpc-main-route-table" {
-  vpc_id         = aws_vpc.redpanda.id
+  vpc_id         = data.aws_vpc.redpanda.id
   route_table_id = aws_route_table.main.id
 }
 

--- a/customer-managed/aws/terraform/security_groups.tf
+++ b/customer-managed/aws/terraform/security_groups.tf
@@ -4,7 +4,7 @@
 resource "aws_security_group" "redpanda_agent" {
   name_prefix = "${var.common_prefix}-agent-"
   description = "Redpanda agent VM"
-  vpc_id      = aws_vpc.redpanda.id
+  vpc_id      = data.aws_vpc.redpanda.id
   ingress     = []
   egress {
     from_port        = 0
@@ -24,7 +24,7 @@ resource "aws_security_group" "redpanda_agent" {
 resource "aws_security_group" "connectors" {
   name_prefix = "${var.common_prefix}-connect-"
   description = "Redpanda connectors nodes"
-  vpc_id      = aws_vpc.redpanda.id
+  vpc_id      = data.aws_vpc.redpanda.id
   lifecycle {
     create_before_destroy = true
   }
@@ -46,7 +46,7 @@ resource "aws_security_group_rule" "connectors" {
 resource "aws_security_group" "utility" {
   name_prefix = "${var.common_prefix}-util-"
   description = "Redpanda utility nodes"
-  vpc_id      = aws_vpc.redpanda.id
+  vpc_id      = data.aws_vpc.redpanda.id
   lifecycle {
     create_before_destroy = true
   }
@@ -68,7 +68,7 @@ resource "aws_security_group_rule" "utility" {
 resource "aws_security_group" "redpanda_node_group" {
   name_prefix = "${var.common_prefix}-rp-"
   description = "Redpanda cluster nodes"
-  vpc_id      = aws_vpc.redpanda.id
+  vpc_id      = data.aws_vpc.redpanda.id
   lifecycle {
     create_before_destroy = true
   }
@@ -110,7 +110,7 @@ resource "aws_security_group_rule" "redpanda_node_group" {
 resource "aws_security_group" "cluster" {
   name_prefix = "${var.common_prefix}-cluster-"
   description = "EKS cluster security group"
-  vpc_id      = aws_vpc.redpanda.id
+  vpc_id      = data.aws_vpc.redpanda.id
   lifecycle {
     create_before_destroy = true
   }
@@ -133,7 +133,7 @@ resource "aws_security_group_rule" "cluster_agent_to_cluster_api" {
   from_port         = 443
   to_port           = 443
   type              = "ingress"
-  cidr_blocks       = [aws_vpc.redpanda.cidr_block]
+  cidr_blocks       = [data.aws_vpc.redpanda.cidr_block]
 }
 
 resource "aws_security_group_rule" "cluster_api_to_node_group" {
@@ -162,7 +162,7 @@ resource "aws_security_group_rule" "cluster_egress_nodes_kubelet" {
 resource "aws_security_group" "node" {
   name_prefix = "${var.common_prefix}-node-"
   description = "EKS node shared security group"
-  vpc_id      = aws_vpc.redpanda.id
+  vpc_id      = data.aws_vpc.redpanda.id
   lifecycle {
     create_before_destroy = true
   }

--- a/customer-managed/aws/terraform/variables.tf
+++ b/customer-managed/aws/terraform/variables.tf
@@ -111,3 +111,21 @@ variable "common_prefix" {
   Text to be included at the start of the name prefix on any objects supporting name prefixes.
   HELP
 }
+
+variable "create_rpk_user" {
+  type        = bool
+  default     = false
+  description = <<-HELP
+  The rpk user is one that can be used to test the minimum necessary permissions. It is not suggested for
+  production use. When true this policy will be created, when false it will be skipped.
+  HELP
+}
+
+variable "vpc_id" {
+  type        = string
+  default     = ""
+  description = <<-HELP
+  If the VPC is created and managed outside of this terraform the ID of the VPC should be provided and then VPC
+  creation will be skipped.
+  HELP
+}


### PR DESCRIPTION
It is likely that the customer has created the VPC and the subnets outside of this terraform and is interested in using this code for creation of Redpanda specific things, like policies and roles in which case it is nice to parameterize the creation of those resources such that they can be skipped.