### PR TITLE
Update the README for AWS customer managed to include permissions boundary

### DIFF
--- a/customer-managed/aws/README.md
+++ b/customer-managed/aws/README.md
@@ -175,6 +175,9 @@ curl -X POST "https://api.redpanda.com/v1beta2/clusters" \
       "cloud_storage_bucket": {
         "arn": "<cloud_storage_bucket_arn from outputs>"
       }
+      "permissions_boundary_policy": {
+        "arn": "<permissions_boundary_policy_arn from outputs>"
+      }
     }
   },
   # <This aws_private_link section is optional, see https://docs.redpanda.com/current/deploy/deployment-option/cloud/aws-privatelink/ for more information>

--- a/customer-managed/aws/terraform/outputs.tf
+++ b/customer-managed/aws/terraform/outputs.tf
@@ -95,7 +95,7 @@ output "byovpc_rpk_user_policy_arns" {
   description = "ARNs of policies associated with the 'rpk user'. Can be used by Redpanda engineers to the assume the role and test provisioning with more limited access."
 }
 
-output "agent_permission_boundary" {
+output "permissions_boundary_policy_arn" {
   value       = aws_iam_policy.agent_permission_boundary.arn
   description = "ARN of the policy boundary which is required to be included on any roles created by the Redpanda agent"
 }


### PR DESCRIPTION
Also updated the name of the output variable to be more in line with what is used in the public API.