### PR TITLE
CIAINFRA-289: Bugfix: Lacking permissions for auto-scaling groups

### DIFF
--- a/customer-managed/aws/terraform/iam_redpanda_agent.tf
+++ b/customer-managed/aws/terraform/iam_redpanda_agent.tf
@@ -254,7 +254,7 @@ data "aws_iam_policy_document" "redpanda_agent1" {
 
         "arn:aws:ec2:*::image/*",
       ],
-    aws_subnet.private.*.arn)
+    [for o in data.aws_subnet.private : o["arn"]])
   }
 
   statement {

--- a/customer-managed/aws/terraform/network.tf
+++ b/customer-managed/aws/terraform/network.tf
@@ -51,6 +51,17 @@ resource "aws_subnet" "private" {
   )
 }
 
+locals {
+  provided_subnet_ids = var.private_subnet_ids
+  created_subnet_ids  = aws_subnet.private.*.id
+  subnet_ids          = length(var.private_subnet_ids) > 0 ? local.provided_subnet_ids : local.created_subnet_ids
+}
+
+data "aws_subnet" "private" {
+  count = length(local.subnet_ids)
+  id    = local.subnet_ids[count.index]
+}
+
 data "aws_vpc_endpoint_service" "s3" {
   service      = "s3"
   service_type = "Gateway"

--- a/customer-managed/aws/terraform/outputs.tf
+++ b/customer-managed/aws/terraform/outputs.tf
@@ -56,8 +56,12 @@ output "public_subnet_ids" {
 }
 
 output "private_subnet_ids" {
-  value       = jsonencode(aws_subnet.private.*.arn)
+  value       = jsonencode([for o in data.aws_subnet.private : o["arn"]])
   description = "Private subnet IDs created"
+  precondition {
+    condition     = length(data.aws_subnet.private) > 0
+    error_message = "Either the variable private_subnet_cidrs or private_subnet_ids is required."
+  }
 }
 
 output "redpanda_agent_security_group_arn" {

--- a/customer-managed/aws/terraform/variables.tf
+++ b/customer-managed/aws/terraform/variables.tf
@@ -44,6 +44,15 @@ variable "private_subnet_cidrs" {
   HELP
 }
 
+variable "private_subnet_ids" {
+  type        = list(string)
+  default     = []
+  description = <<-HELP
+  List of private subnet ids if created externally to this terraform. One of private_subnet_cidrs or private_subnet_ids
+  must be provided.
+  HELP
+}
+
 variable "zones" {
   type = list(string)
   default = [


### PR DESCRIPTION
After a [recent change](https://github.com/redpanda-data/cloud-examples/pull/13) to enable subnet creation to occur outside of this package it caused an issue where the `ec2:RunInstances` permission was no longer granted on the subnet resources.

With this change the user will be required to pass in either subnet cidrs, in which case we will create the subnets, or a list of subnet ids if created externally.

Either way the resulting subnets are identified and `ec2:RunInstances` will be granted on the subnets.