### PR TITLE
bugfix: Allow auto-scaling of connectors node pool

### DIFF
--- a/customer-managed/aws/terraform/iam_connectors_node_group.tf
+++ b/customer-managed/aws/terraform/iam_connectors_node_group.tf
@@ -34,58 +34,11 @@ resource "aws_iam_instance_profile" "connectors_node_group" {
   )
 }
 
-data "aws_iam_policy_document" "connectors_autoscaler_policy" {
-  statement {
-    effect = "Allow"
-    actions = [
-      # The following autoscaling actions do not support resource types
-      # https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonec2autoscaling.html
-      "autoscaling:DescribeAutoScalingGroups",
-      "autoscaling:DescribeAutoScalingInstances",
-      "autoscaling:DescribeLaunchConfigurations",
-      "autoscaling:DescribeTags",
-
-      # The following ec2 actions do not support resource types
-      # https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonec2.html
-      "ec2:DescribeInstanceTypes",
-      "ec2:DescribeLaunchTemplateVersions",
-    ]
-    resources = ["*"]
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "autoscaling:SetDesiredCapacity",
-      "autoscaling:TerminateInstanceInAutoScalingGroup",
-    ]
-    resources = [
-      "arn:aws:autoscaling:${var.region}:${local.aws_account_id}:autoScalingGroup:*:autoScalingGroupName/redpanda-*-connect-*",
-    ]
-    dynamic "condition" {
-      for_each = var.condition_tags
-      content {
-        test     = "StringEquals"
-        variable = "aws:ResourceTag/${condition.key}"
-        values = [
-          condition.value,
-        ]
-      }
-    }
-  }
-}
-
-resource "aws_iam_policy" "connectors_autoscaler_policy" {
-  name_prefix = "${var.common_prefix}-rp-autoscaler-"
-  policy      = data.aws_iam_policy_document.connectors_autoscaler_policy.json
-}
-
 resource "aws_iam_role_policy_attachment" "connectors_node_group" {
   for_each = {
     "1" = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
     "2" = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
     "3" = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
-    "4" = aws_iam_policy.connectors_autoscaler_policy.arn
   }
   policy_arn = each.value
   role       = aws_iam_role.connectors_node_group.name

--- a/customer-managed/aws/terraform/iam_utility_node_group.tf
+++ b/customer-managed/aws/terraform/iam_utility_node_group.tf
@@ -24,7 +24,7 @@ data "aws_iam_policy_document" "cluster_autoscaler_policy" {
       "autoscaling:TerminateInstanceInAutoScalingGroup",
     ]
     resources = [
-      "arn:aws:autoscaling:${var.region}:${local.aws_account_id}:autoScalingGroup:*:autoScalingGroupName/redpanda-*-util-*",
+      "arn:aws:autoscaling:${var.region}:${local.aws_account_id}:autoScalingGroup:*:autoScalingGroupName/redpanda-*",
     ]
     dynamic "condition" {
       for_each = var.condition_tags


### PR DESCRIPTION
The previous change is being reverted, it is not the connectors node pool role that requires `autoscaling:SetDesiredCapacity` it is the autoscaler which runs in the utility node pool, it requires access to the `redpanda-*-connect-*` autoscaling group.