### PR TITLE
Minor changes to default behavior

### DIFF
--- a/customer-managed/aws/terraform/network.tf
+++ b/customer-managed/aws/terraform/network.tf
@@ -4,7 +4,7 @@ locals {
 
 resource "aws_vpc" "redpanda" {
   count                = local.create_vpc ? 1 : 0
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = var.vpc_cidr_block
   enable_dns_support   = true
   enable_dns_hostnames = true
 }

--- a/customer-managed/aws/terraform/security_groups.tf
+++ b/customer-managed/aws/terraform/security_groups.tf
@@ -75,13 +75,7 @@ resource "aws_security_group" "redpanda_node_group" {
 }
 
 locals {
-  rp_node_group_cidr_blocks = var.public_cluster ? [
-
-    // only used in the event that you want a public cluster, when the variable public_cluster is true
-    "0.0.0.0/0"
-
-    ] : [
-
+  rp_node_group_cidr_blocks = [
     // RFC 6598 reserved prefix for shared address space
     // https://datatracker.ietf.org/doc/html/rfc6598
     "100.64.0.0/10",
@@ -91,9 +85,9 @@ locals {
     "172.16.0.0/12",
     "192.168.0.0/16",
     "10.0.0.0/8",
-
   ]
 }
+
 resource "aws_security_group_rule" "redpanda_node_group" {
   security_group_id = aws_security_group.redpanda_node_group.id
   protocol          = "tcp"

--- a/customer-managed/aws/terraform/variables.tf
+++ b/customer-managed/aws/terraform/variables.tf
@@ -15,15 +15,8 @@ variable "aws_account_id" {
 }
 
 variable "public_subnet_cidrs" {
-  type = list(string)
-  default = [
-    "10.0.1.0/24",
-    "10.0.3.0/24",
-    "10.0.5.0/24",
-    "10.0.7.0/24",
-    "10.0.9.0/24",
-    "10.0.11.0/24"
-  ]
+  type        = list(string)
+  default     = []
   description = <<-HELP
   One public subnet will be created per cidr in this list.
   HELP
@@ -62,15 +55,6 @@ variable "zones" {
   ]
   description = <<-HELP
   The Availability Zone IDs to assign to the subnets, will be round-robined for each public and private subnet cidr.
-  HELP
-}
-
-variable "public_cluster" {
-  type        = bool
-  default     = false
-  description = <<-HELP
-  When true the security groups will be configured in a way to allow public ingress to redpanda. When false ingress will
-  be restricted to internal addresses.
   HELP
 }
 
@@ -136,6 +120,14 @@ variable "vpc_id" {
   description = <<-HELP
   If the VPC is created and managed outside of this terraform the ID of the VPC should be provided and then VPC
   creation will be skipped.
+  HELP
+}
+
+variable "vpc_cidr_block" {
+  type        = string
+  default     = "10.0.0.0/16"
+  description = <<-HELP
+  If the VPC is created and managed by this terraform this will be the cidr block of that VPC.
   HELP
 }
 


### PR DESCRIPTION
I'd like the default behavior of the code to more closely align with what our customers commonly need.

1. Remove `public_cluster` variable. Customer-Managed VPC clusters are never public.
2. Default the list of `public_subnet_cidrs` to be empty. All subnets are typically created external to this code. The primary use case for `public_subnet_cidrs` is our own internal testing.
3. Add new variable `vpc_cidr_block` which is only used when `vpc_id` is not provided. Since it is possible to provide a list of `private_subnet_cidrs` it should also be possible to set the CIDR block for the VPC if it is being created.