### PR TITLE
Add and format TF output to  Azure customer managed resources

### DIFF
--- a/customer-managed/azure/terraform/outputs.tf
+++ b/customer-managed/azure/terraform/outputs.tf
@@ -1,6 +1,166 @@
+output "management_bucket_storage_account_name" {
+  description = "Management bucket storage account name"
+  value       = azurerm_storage_account.management.name
+}
+
+output "management_bucket_storage_container_name" {
+  description = "Management bucket storage container name"
+  value       = azurerm_storage_container.management.name
+}
+
+output "vnet_name" {
+  description = "VNet name"
+  value       = azurerm_virtual_network.redpanda.name
+}
+
+output "agent_private_subnet_name" {
+  description = "Agent private subnet name"
+  value       = azurerm_subnet.private["agent-private"].name
+}
+
+output "rp_0_pods_subnet_name" {
+  description = "Redpanda 0 pods subnet name"
+  value       = azurerm_subnet.private["rp-0-pods"].name
+}
+
+output "rp_0_vnet_subnet_name" {
+  description = "Redpanda 0 vnet subnet name"
+  value       = azurerm_subnet.private["rp-0-vnet"].name
+}
+
+output "rp_1_pods_subnet_name" {
+  description = "Redpanda 1 pods subnet name"
+  value       = azurerm_subnet.private["rp-1-pods"].name
+}
+
+output "rp_1_vnet_subnet_name" {
+  description = "Redpanda 1 vnet subnet name"
+  value       = azurerm_subnet.private["rp-1-vnet"].name
+}
+output "rp_2_pods_subnet_name" {
+  description = "Redpanda 2 pods subnet name"
+  value       = azurerm_subnet.private["rp-2-pods"].name
+}
+
+output "rp_2_vnet_subnet_name" {
+  description = "Redpanda 2 vnet subnet name"
+  value       = azurerm_subnet.private["rp-2-vnet"].name
+}
+
+output "rp_connect_pods_subnet_name" {
+  description = "Redpanda connect pods subnet name"
+  value       = azurerm_subnet.private["connect-pod"].name
+}
+
+output "rp_connect_vnet_subnet_name" {
+  description = "Redpanda connect vnet subnet name"
+  value       = azurerm_subnet.private["connect-vnet"].name
+}
+
+output "kafka_connect_pods_subnet_name" {
+  description = "Kafka connect pods subnet name"
+  value       = azurerm_subnet.private["kafka-connect-pod"].name
+}
+
+output "kafka_connect_vnet_subnet_name" {
+  description = "Kafka connect vnet subnet name"
+  value       = azurerm_subnet.private["kafka-connect-vnet"].name
+}
+
+output "system_pods_subnet_name" {
+  description = "System pods subnet name"
+  value       = azurerm_subnet.private["system-pod"].name
+}
+
+output "system_vnet_subnet_name" {
+  description = "System vnet subnet name"
+  value       = azurerm_subnet.private["system-vnet"].name
+}
+
+output "egress_subnet_name" {
+  description = "Egress subnet name"
+  value       = azurerm_subnet.public["agent-public"].name
+}
+
+
+output "redpanda_resource_group_name" {
+  description = "Redpanda resource group name"
+  value       = azurerm_resource_group.redpanda.name
+}
+
+output "storage_resource_group_name" {
+  description = "Storage resource group name"
+  value       = azurerm_resource_group.storage.name
+}
+
+output "network_resource_group_name" {
+  description = "Network resource group name"
+  value       = azurerm_resource_group.network.name
+}
+
+output "iam_resource_group_name" {
+  description = "IAM resource group name"
+  value       = azurerm_resource_group.iam.name
+}
+
+output "agent_user_assigned_identity_name" {
+  description = "Agent user assigned identity name"
+  value       = azurerm_user_assigned_identity.redpanda_agent.name
+}
+
+output "cert_manager_user_assigned_identity_name" {
+  description = "Cert manager user assigned identity name"
+  value       = azurerm_user_assigned_identity.cert_manager.name
+}
+
+output "external_dns_user_assigned_identity_name" {
+  description = "External DNS user assigned identity name"
+  value       = azurerm_user_assigned_identity.external_dns.name
+}
+
+output "aks_user_assigned_identity_name" {
+  description = "AKS user assigned identity name"
+  value       = azurerm_user_assigned_identity.aks.name
+}
+
+output "cluster_user_assigned_identity_name" {
+  description = "Redpanda cluster user assigned identity name"
+  value       = azurerm_user_assigned_identity.redpanda_cluster.name
+}
+
+output "console_user_assigned_identity_name" {
+  description = "Redpanda console user assigned identity name"
+  value       = azurerm_user_assigned_identity.redpanda_console.name
+}
+
+output "management_key_vault_name" {
+  description = "Management key vault name"
+  value       = var.redpanda_management_key_vault_name != "" ? azurerm_key_vault.vault[0].name : ""
+}
+
+output "console_key_vault_name" {
+  description = "Console key vault name"
+  value       = var.redpanda_console_key_vault_name != "" ? azurerm_key_vault.console[0].name : ""
+}
+
+output "tiered_storage_account_name" {
+  description = "tiered storage account name"
+  value       = azurerm_storage_account.tiered_storage.name
+}
+
+output "tiered_storage_container_name" {
+  description = "tiered storage container name"
+  value       = azurerm_storage_container.tiered_storage.name
+}
+
+output "redpanda_security_group_name" {
+  description = "Redpanda security group name"
+  value       = azurerm_network_security_group.redpanda_cluster.name
+}
+
 output "resource_groups" {
   description = "Resource groups"
-  value = {
+  value = jsonencode({
     "redpanda" : {
       "name" : azurerm_resource_group.redpanda.name,
       "id" : azurerm_resource_group.redpanda.id
@@ -17,33 +177,33 @@ output "resource_groups" {
       "name" : azurerm_resource_group.iam.name,
       "id" : azurerm_resource_group.iam.id
     }
-  }
+  })
 }
 
 output "roles" {
   description = "IAM roles"
-  value = {
+  value = jsonencode({
     "agent" : azurerm_role_definition.redpanda_agent.id,
     "console" : azurerm_role_definition.redpanda_console.id,
     "private-link" : azurerm_role_definition.redpanda_private_link.id
-  }
+  })
 }
 
 output "identities" {
   description = "User assigned identities"
-  value = {
+  value = jsonencode({
     "agent" : azurerm_user_assigned_identity.redpanda_agent.id,
     "cert-manager" : azurerm_user_assigned_identity.cert_manager.id,
     "external-dns" : azurerm_user_assigned_identity.external_dns.id,
     "aks" : azurerm_user_assigned_identity.aks.id,
     "redpanda-cluster" : azurerm_user_assigned_identity.redpanda_cluster.id,
     "redpanda-console" : azurerm_user_assigned_identity.redpanda_console.id
-  }
+  })
 }
 
 output "networks" {
   description = "Networks"
-  value = {
+  value = jsonencode({
     "vnet" : {
       "name" : azurerm_virtual_network.redpanda.name,
       "resource_group" : azurerm_virtual_network.redpanda.resource_group_name,
@@ -62,19 +222,19 @@ output "networks" {
       }
     }
     "subnet-cidrs-aks" : var.reserved_subnet_cidrs
-  }
+  })
 }
 
 output "security" {
   description = "Security groups"
-  value = {
+  value = jsonencode({
     "redpanda-cluster" : azurerm_network_security_group.redpanda_cluster.id
-  }
+  })
 }
 
 output "storage" {
   description = "Storage"
-  value = {
+  value = jsonencode({
     "management" : {
       "storage-account-id" : azurerm_storage_account.management.id,
       "bucket" : azurerm_storage_container.management.id
@@ -83,13 +243,13 @@ output "storage" {
       "storage-account-id" : azurerm_storage_account.tiered_storage.id,
       "bucket" : azurerm_storage_container.tiered_storage.id
     }
-  }
+  })
 }
 
 output "vault" {
   description = "Key vault"
-  value = {
+  value = jsonencode({
     "redpanda-cluster" : var.redpanda_console_key_vault_name != "" ? azurerm_key_vault.vault[0].id : ""
     "redpanda-console" : var.redpanda_console_key_vault_name != "" ? azurerm_key_vault.console[0].id : ""
-  }
+  })
 }

--- a/customer-managed/azure/terraform/roles.tf
+++ b/customer-managed/azure/terraform/roles.tf
@@ -110,7 +110,7 @@ resource "azurerm_role_definition" "redpanda_private_link" {
   assignable_scopes = [
     azurerm_resource_group.redpanda.id
   ]
-  name        = var.redpanda_private_link_role_name
+  name        = "${var.resource_name_prefix}${var.redpanda_private_link_role_name}"
   scope       = azurerm_resource_group.redpanda.id
   description = "Redpanda AKS Private Link Service"
   permissions {

--- a/customer-managed/azure/terraform/routing.tf
+++ b/customer-managed/azure/terraform/routing.tf
@@ -9,7 +9,7 @@ locals {
 
 resource "azurerm_nat_gateway" "redpanda" {
   count                   = local.create_nat
-  name                    = "${var.resource_name_prefix}ngw-${var.region}"
+  name                    = "${var.resource_name_prefix}-ngw-${var.region}"
   location                = var.region
   resource_group_name     = azurerm_resource_group.network.name
   sku_name                = "Standard"


### PR DESCRIPTION
Add the TF output for certification tests, and format the existing output to be `map[string]string`.