### PR TITLE
Azure BYO VNET: support kafka connect user assigned identity

### DIFF
--- a/customer-managed/azure/terraform/identities.tf
+++ b/customer-managed/azure/terraform/identities.tf
@@ -33,3 +33,9 @@ resource "azurerm_user_assigned_identity" "redpanda_console" {
   name                = "${var.resource_name_prefix}${var.redpanda_console_identity_name}"
   resource_group_name = azurerm_resource_group.iam.name
 }
+
+resource "azurerm_user_assigned_identity" "kafka_connect" {
+  location            = azurerm_resource_group.iam.location
+  name                = "${var.resource_name_prefix}${var.kafka_connect_identity_name}"
+  resource_group_name = azurerm_resource_group.iam.name
+}

--- a/customer-managed/azure/terraform/role_assignments.tf
+++ b/customer-managed/azure/terraform/role_assignments.tf
@@ -121,3 +121,9 @@ resource "azurerm_role_assignment" "external_dns_rgreader" {
   principal_type = "ServicePrincipal"
 }
 
+resource "azurerm_role_assignment" "kafka_connect" {
+  count              = local.create_role_assignment
+  principal_id       = azurerm_user_assigned_identity.kafka_connect.principal_id
+  scope              = azurerm_key_vault.console[0].id
+  role_definition_id = azurerm_role_definition.kafka_connect.role_definition_resource_id
+}

--- a/customer-managed/azure/terraform/roles.tf
+++ b/customer-managed/azure/terraform/roles.tf
@@ -125,3 +125,21 @@ resource "azurerm_role_definition" "redpanda_private_link" {
     ]
   }
 }
+
+resource "azurerm_role_definition" "kafka_connect" {
+  name        = "${var.resource_name_prefix}${var.kafka_connect_role_name}"
+  description = "Redpanda Kafka Connect Role"
+  scope       = azurerm_resource_group.redpanda.id
+  assignable_scopes = [
+    azurerm_resource_group.redpanda.id
+  ]
+  permissions {
+    # https://learn.microsoft.com/en-us/azure/role-based-access-control/permissions/security#microsoftkeyvault
+    actions = [
+      "Microsoft.KeyVault/vaults/secrets/read",
+    ]
+    data_actions = [
+      "Microsoft.KeyVault/vaults/secrets/readMetadata/action",
+    ]
+  }
+}

--- a/customer-managed/azure/terraform/vars.customer_input.tf
+++ b/customer-managed/azure/terraform/vars.customer_input.tf
@@ -81,6 +81,14 @@ variable "redpanda_console_identity_name" {
   HELP
 }
 
+variable "kafka_connect_identity_name" {
+  type        = string
+  default     = "kafka-connect-uai"
+  description = <<-HELP
+    The name of user assigned identity for Kafka Connect.
+  HELP
+}
+
 ###########################################################################
 # Storage vars: resource groups and roles
 ###########################################################################

--- a/customer-managed/azure/terraform/vars.iam.tf
+++ b/customer-managed/azure/terraform/vars.iam.tf
@@ -24,3 +24,11 @@ variable "redpanda_private_link_role_name" {
     The role name of Redpanda private link.
   HELP
 }
+
+variable "kafka_connect_role_name" {
+  type        = string
+  default     = "kafka-connect-role"
+  description = <<-HELP
+    The role name of Kafka Connect.
+  HELP
+}


### PR DESCRIPTION
Changes for supporting Kafka connect user assigned identity in Azure BYO VNET.