### PR TITLE
Azure BYOVNET: Support using existing resource groups in deploying custom resources

### DIFF
--- a/customer-managed/azure/terraform/README.md
+++ b/customer-managed/azure/terraform/README.md
@@ -27,23 +27,19 @@ No modules.
 | [azurerm_network_security_group.redpanda_connectors](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/network_security_group) | resource |
 | [azurerm_network_security_rule.allow_inbound_to_redpanda_brokers_nodeport](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/network_security_rule) | resource |
 | [azurerm_public_ip_prefix.redpanda](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/public_ip_prefix) | resource |
-| [azurerm_resource_group.iam](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/resource_group) | resource |
-| [azurerm_resource_group.network](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/resource_group) | resource |
-| [azurerm_resource_group.redpanda](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/resource_group) | resource |
-| [azurerm_resource_group.storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/resource_group) | resource |
+| [azurerm_resource_group.all](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/resource_group) | resource |
+| [azurerm_role_assignment.agent](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.aks_network_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.assign_identity_storage_blob_data_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.cert_manager](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.external_dns_rgreader](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.external_dns_zone_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.redpanda_agent_iam](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.redpanda_agent_network](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.redpanda_agent_redpanda](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.redpanda_agent_tiered_storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.kafka_connect](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.redpanda_cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.redpanda_console](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.redpanda_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.vault_secrets_officer](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_definition.kafka_connect](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.redpanda_agent](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.redpanda_console](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.redpanda_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/role_definition) | resource |
@@ -58,12 +54,14 @@ No modules.
 | [azurerm_user_assigned_identity.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/user_assigned_identity) | resource |
 | [azurerm_user_assigned_identity.cert_manager](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/user_assigned_identity) | resource |
 | [azurerm_user_assigned_identity.external_dns](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/user_assigned_identity) | resource |
+| [azurerm_user_assigned_identity.kafka_connect](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/user_assigned_identity) | resource |
 | [azurerm_user_assigned_identity.redpanda_agent](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/user_assigned_identity) | resource |
 | [azurerm_user_assigned_identity.redpanda_cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/user_assigned_identity) | resource |
 | [azurerm_user_assigned_identity.redpanda_console](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/user_assigned_identity) | resource |
 | [azurerm_virtual_network.redpanda](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/resources/virtual_network) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/data-sources/client_config) | data source |
 | [azurerm_location.redpanda](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/data-sources/location) | data source |
+| [azurerm_resource_group.all](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/data-sources/resource_group) | data source |
 | [azurerm_virtual_network.redpanda](https://registry.terraform.io/providers/hashicorp/azurerm/3.98.0/docs/data-sources/virtual_network) | data source |
 
 ## Inputs
@@ -79,32 +77,36 @@ No modules.
 | <a name="input_azure_use_msi"></a> [azure\_use\_msi](#input\_azure\_use\_msi) | Whether to use Azure Managed Identity authentication (formerly MSI) | `bool` | `false` | no |
 | <a name="input_azure_use_oidc"></a> [azure\_use\_oidc](#input\_azure\_use\_oidc) | Whether to use Azure OIDC authentication | `bool` | `false` | no |
 | <a name="input_create_nat"></a> [create\_nat](#input\_create\_nat) | Whether to create NAT gateway and its assoications | `bool` | `true` | no |
+| <a name="input_create_resource_groups"></a> [create\_resource\_groups](#input\_create\_resource\_groups) | If true, the module will create resource groups for Redpanda resources. | `bool` | `true` | no |
 | <a name="input_create_role_assignment"></a> [create\_role\_assignment](#input\_create\_role\_assignment) | Whether to create role assigments. | `bool` | `true` | no |
 | <a name="input_egress_subnets"></a> [egress\_subnets](#input\_egress\_subnets) | A list of CIDR ranges to use for the *egress* subnets. They needs to be at least /24. | `map(map(string))` | <pre>{<br>  "agent-public": {<br>    "cidr": "10.0.0.0/24",<br>    "name": "snet-agent-public"<br>  }<br>}</pre> | no |
+| <a name="input_kafka_connect_identity_name"></a> [kafka\_connect\_identity\_name](#input\_kafka\_connect\_identity\_name) | The name of user assigned identity for Kafka Connect. | `string` | `"kafka-connect-uai"` | no |
+| <a name="input_kafka_connect_role_name"></a> [kafka\_connect\_role\_name](#input\_kafka\_connect\_role\_name) | The role name of Kafka Connect. | `string` | `"kafka-connect-role"` | no |
 | <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | A list of CIDR ranges to use for the *private* subnets. They needs to be at least /24. | `map(map(string))` | <pre>{<br>  "agent-private": {<br>    "cidr": "10.0.3.0/24",<br>    "name": "snet-agent-private"<br>  },<br>  "connect-pod": {<br>    "cidr": "10.0.10.0/24",<br>    "name": "snet-connect-pods"<br>  },<br>  "connect-vnet": {<br>    "cidr": "10.0.11.0/24",<br>    "name": "snet-connect-vnet"<br>  },<br>  "kafka-connect-pod": {<br>    "cidr": "10.0.12.0/24",<br>    "name": "snet-kafka-connect-pods"<br>  },<br>  "kafka-connect-vnet": {<br>    "cidr": "10.0.13.0/24",<br>    "name": "snet-kafka-connect-vnet"<br>  },<br>  "rp-0-pods": {<br>    "cidr": "10.0.4.0/24",<br>    "name": "snet-rp-0-pods"<br>  },<br>  "rp-0-vnet": {<br>    "cidr": "10.0.5.0/24",<br>    "name": "snet-rp-0-vnet"<br>  },<br>  "rp-1-pods": {<br>    "cidr": "10.0.6.0/24",<br>    "name": "snet-rp-1-pods"<br>  },<br>  "rp-1-vnet": {<br>    "cidr": "10.0.7.0/24",<br>    "name": "snet-rp-1-vnet"<br>  },<br>  "rp-2-pods": {<br>    "cidr": "10.0.8.0/24",<br>    "name": "snet-rp-2-pods"<br>  },<br>  "rp-2-vnet": {<br>    "cidr": "10.0.9.0/24",<br>    "name": "snet-rp-2-vnet"<br>  },<br>  "system-pod": {<br>    "cidr": "10.0.1.0/24",<br>    "name": "snet-system-pods"<br>  },<br>  "system-vnet": {<br>    "cidr": "10.0.2.0/24",<br>    "name": "snet-system-vnet"<br>  }<br>}</pre> | no |
 | <a name="input_redpanda_agent_identity_name"></a> [redpanda\_agent\_identity\_name](#input\_redpanda\_agent\_identity\_name) | The name of user assigned identity for Redpanda agent. | `string` | `"agent-uai"` | no |
 | <a name="input_redpanda_agent_role_name"></a> [redpanda\_agent\_role\_name](#input\_redpanda\_agent\_role\_name) | The role name of Redpanda agent. | `string` | `"agent-role"` | no |
 | <a name="input_redpanda_cert_manager_identity_name"></a> [redpanda\_cert\_manager\_identity\_name](#input\_redpanda\_cert\_manager\_identity\_name) | The name of user assigned identity for cert-manager. | `string` | `"cert-manager-uai"` | no |
 | <a name="input_redpanda_cluster_identity_name"></a> [redpanda\_cluster\_identity\_name](#input\_redpanda\_cluster\_identity\_name) | The name of user assigned identity for Redpanda cluster. | `string` | `"cluster-uai"` | no |
 | <a name="input_redpanda_console_identity_name"></a> [redpanda\_console\_identity\_name](#input\_redpanda\_console\_identity\_name) | The name of user assigned identity for Redpanda Console. | `string` | `"console-uai"` | no |
-| <a name="input_redpanda_console_key_vault_name"></a> [redpanda\_console\_key\_vault\_name](#input\_redpanda\_console\_key\_vault\_name) | The name of key vault for Redpanda Console | `string` | `"consolevault"` | no |
+| <a name="input_redpanda_console_key_vault_name"></a> [redpanda\_console\_key\_vault\_name](#input\_redpanda\_console\_key\_vault\_name) | The name of key vault for Redpanda Console | `string` | `"console-vault"` | no |
 | <a name="input_redpanda_console_role_name"></a> [redpanda\_console\_role\_name](#input\_redpanda\_console\_role\_name) | The role name of Redpanda Console. | `string` | `"console-role"` | no |
 | <a name="input_redpanda_external_dns_identity_name"></a> [redpanda\_external\_dns\_identity\_name](#input\_redpanda\_external\_dns\_identity\_name) | The name of user assigned identity for external-dns. | `string` | `"external-dns-uai"` | no |
 | <a name="input_redpanda_iam_resource_group_name"></a> [redpanda\_iam\_resource\_group\_name](#input\_redpanda\_iam\_resource\_group\_name) | The name of the resource group to place Redpanda IAM resources. | `string` | `"iam-rg"` | no |
-| <a name="input_redpanda_management_key_vault_name"></a> [redpanda\_management\_key\_vault\_name](#input\_redpanda\_management\_key\_vault\_name) | The name of key vault for Redpanda management | `string` | `"redpandavault"` | no |
-| <a name="input_redpanda_management_storage_account_name"></a> [redpanda\_management\_storage\_account\_name](#input\_redpanda\_management\_storage\_account\_name) | Azure Blob Storage account name for Redpanda management storage. | `string` | `"management"` | no |
-| <a name="input_redpanda_management_storage_container_name"></a> [redpanda\_management\_storage\_container\_name](#input\_redpanda\_management\_storage\_container\_name) | Name of the storage container for Redpanda management storage | `string` | `"management"` | no |
+| <a name="input_redpanda_management_key_vault_name"></a> [redpanda\_management\_key\_vault\_name](#input\_redpanda\_management\_key\_vault\_name) | The name of key vault for Redpanda management | `string` | `"rp-vault"` | no |
+| <a name="input_redpanda_management_storage_account_name"></a> [redpanda\_management\_storage\_account\_name](#input\_redpanda\_management\_storage\_account\_name) | Azure Blob Storage account name for Redpanda management storage. | `string` | `"managementa"` | no |
+| <a name="input_redpanda_management_storage_container_name"></a> [redpanda\_management\_storage\_container\_name](#input\_redpanda\_management\_storage\_container\_name) | Name of the storage container for Redpanda management storage | `string` | `"managementc"` | no |
 | <a name="input_redpanda_network_resource_group_name"></a> [redpanda\_network\_resource\_group\_name](#input\_redpanda\_network\_resource\_group\_name) | The name of the resource group to place Redpanda network resources. | `string` | `"network-rg"` | no |
 | <a name="input_redpanda_private_link_role_name"></a> [redpanda\_private\_link\_role\_name](#input\_redpanda\_private\_link\_role\_name) | The role name of Redpanda private link. | `string` | `"private-link-role"` | no |
 | <a name="input_redpanda_resource_group_name"></a> [redpanda\_resource\_group\_name](#input\_redpanda\_resource\_group\_name) | The name of the resource group to place Redpanda resources. | `string` | `"redpanda-rg"` | no |
 | <a name="input_redpanda_security_group_name"></a> [redpanda\_security\_group\_name](#input\_redpanda\_security\_group\_name) | The name of Redpanda cluster security group | `string` | `"redpanda-nsg"` | no |
 | <a name="input_redpanda_storage_resource_group_name"></a> [redpanda\_storage\_resource\_group\_name](#input\_redpanda\_storage\_resource\_group\_name) | The name of the resource group to place Redpanda storage resources. | `string` | `"storage-rg"` | no |
-| <a name="input_redpanda_tiered_storage_account_name"></a> [redpanda\_tiered\_storage\_account\_name](#input\_redpanda\_tiered\_storage\_account\_name) | Azure Blob Storage account name for Redpanda tiered storage. | `string` | `"tieredstorage"` | no |
-| <a name="input_redpanda_tiered_storage_container_name"></a> [redpanda\_tiered\_storage\_container\_name](#input\_redpanda\_tiered\_storage\_container\_name) | Name of the storage container for Redpanda tiered storage | `string` | `"tieredstorage"` | no |
+| <a name="input_redpanda_tiered_storage_account_name"></a> [redpanda\_tiered\_storage\_account\_name](#input\_redpanda\_tiered\_storage\_account\_name) | Azure Blob Storage account name for Redpanda tiered storage. | `string` | `"tieredstoragea"` | no |
+| <a name="input_redpanda_tiered_storage_container_name"></a> [redpanda\_tiered\_storage\_container\_name](#input\_redpanda\_tiered\_storage\_container\_name) | Name of the storage container for Redpanda tiered storage | `string` | `"tieredstoragec"` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region where the resources live. | `string` | `"eastus"` | no |
 | <a name="input_reserved_subnet_cidrs"></a> [reserved\_subnet\_cidrs](#input\_reserved\_subnet\_cidrs) | Reserved CIDRs for AKS | `map(string)` | <pre>{<br>  "k8s-service": "10.0.15.0/24"<br>}</pre> | no |
-| <a name="input_resource_name_prefix"></a> [resource\_name\_prefix](#input\_resource\_name\_prefix) | The prefix added to the name of resource. | `string` | `"pz-"` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Tags to use when labeling resources. These will be set inside the provider block<br>as default tags. | `map(string)` | `{}` | no |
+| <a name="input_resource_group_name_prefix"></a> [resource\_group\_name\_prefix](#input\_resource\_group\_name\_prefix) | The prefix added to the name of resource group. | `string` | `""` | no |
+| <a name="input_resource_name_prefix"></a> [resource\_name\_prefix](#input\_resource\_name\_prefix) | The prefix added to the name of non resource group resource. | `string` | `"pz-"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to use when labeling resources. These will be set inside the provider block<br>as default tags. | `map(string)` | n/a | yes |
 | <a name="input_vnet_addresses"></a> [vnet\_addresses](#input\_vnet\_addresses) | The list of IP address prefixes used by vnet. | `list(string)` | <pre>[<br>  "10.0.0.0/20"<br>]</pre> | no |
 | <a name="input_vnet_name"></a> [vnet\_name](#input\_vnet\_name) | The name of the network. If empty, a VNET will be created. | `string` | `""` | no |
 | <a name="input_zones"></a> [zones](#input\_zones) | Physical availability zone ID. Ex: eastus-az1, eastus-az3, eastus-az2 | `list(string)` | <pre>[<br>  "eastus-az2"<br>]</pre> | no |
@@ -125,6 +127,7 @@ No modules.
 | <a name="output_iam_resource_group_name"></a> [iam\_resource\_group\_name](#output\_iam\_resource\_group\_name) | IAM resource group name |
 | <a name="output_identities"></a> [identities](#output\_identities) | User assigned identities |
 | <a name="output_kafka_connect_pods_subnet_name"></a> [kafka\_connect\_pods\_subnet\_name](#output\_kafka\_connect\_pods\_subnet\_name) | Kafka connect pods subnet name |
+| <a name="output_kafka_connect_user_assigned_identity_name"></a> [kafka\_connect\_user\_assigned\_identity\_name](#output\_kafka\_connect\_user\_assigned\_identity\_name) | Redpanda Kafka Connect user assigned identity name |
 | <a name="output_kafka_connect_vnet_subnet_name"></a> [kafka\_connect\_vnet\_subnet\_name](#output\_kafka\_connect\_vnet\_subnet\_name) | Kafka connect vnet subnet name |
 | <a name="output_management_bucket_storage_account_name"></a> [management\_bucket\_storage\_account\_name](#output\_management\_bucket\_storage\_account\_name) | Management bucket storage account name |
 | <a name="output_management_bucket_storage_container_name"></a> [management\_bucket\_storage\_container\_name](#output\_management\_bucket\_storage\_container\_name) | Management bucket storage container name |

--- a/customer-managed/azure/terraform/resource_groups.tf
+++ b/customer-managed/azure/terraform/resource_groups.tf
@@ -6,7 +6,7 @@ locals {
 
   resource_group_names = distinct([local.redpanda_resource_group_name, local.redpanda_storage_resource_group_name, local.redpanda_network_resource_group_name, local.redpanda_iam_resource_group_name])
 
-  resource_groups                 = { for rg in azurerm_resource_group.all : rg.name => rg }
+  resource_groups                 = { for rg in(var.create_resource_groups ? azurerm_resource_group.all : data.azurerm_resource_group.all) : rg.name => rg }
   redpanda_resource_group         = local.resource_groups[local.redpanda_resource_group_name]
   redpanda_storage_resource_group = local.resource_groups[local.redpanda_storage_resource_group_name]
   redpanda_network_resource_group = local.resource_groups[local.redpanda_network_resource_group_name]
@@ -16,10 +16,15 @@ locals {
 }
 
 resource "azurerm_resource_group" "all" {
-  for_each = toset(local.resource_group_names)
+  for_each = var.create_resource_groups ? toset(local.resource_group_names) : []
 
   name     = each.value
   location = var.region
 
   tags = var.tags
+}
+
+data "azurerm_resource_group" "all" {
+  for_each = var.create_resource_groups ? [] : toset(local.resource_group_names)
+  name     = each.value
 }

--- a/customer-managed/azure/terraform/vars.customer_input.tf
+++ b/customer-managed/azure/terraform/vars.customer_input.tf
@@ -1,6 +1,14 @@
 ###########################################################################
 # IAM vars: resource groups and roles
 ###########################################################################
+variable "create_resource_groups" {
+  type        = bool
+  default     = true
+  description = <<-HELP
+    If true, the module will create resource groups for Redpanda resources.
+  HELP
+}
+
 variable "redpanda_resource_group_name" {
   type        = string
   default     = "redpanda-rg"


### PR DESCRIPTION
Created a TF var `create_resource_groups`. If set to `false`, the TF will use existing resource groups instead of creating them.
The default value of the TF var is `true`.

#### Sample var file using existing resource group.
[byovnet.use-existing-rg.auto.tfvars.json](https://github.com/user-attachments/files/18014778/byovnet.use-existing-rg.auto.tfvars.json)
