### PR TITLE
aws/eks: Allow Redpanda Cloud agent to update thumbprint list

### DIFF
--- a/customer-managed/aws/terraform/iam_redpanda_agent.tf
+++ b/customer-managed/aws/terraform/iam_redpanda_agent.tf
@@ -448,6 +448,28 @@ data "aws_iam_policy_document" "redpanda_agent2" {
       }
     }
   }
+
+  statement {
+    sid    = "RedpandaAgentEKSOIDCProviderCACertThumbprintUpdate"
+    effect = "Allow"
+    actions = [
+      "iam:UpdateOpenIDConnectProviderThumbprint",
+    ]
+    resources = [
+      "arn:aws:iam::${local.aws_account_id}:oidc-provider/oidc.eks.*.amazonaws.com",
+      "arn:aws:iam::${local.aws_account_id}:oidc-provider/oidc.eks.*.amazonaws.com/id/*",
+    ]
+    dynamic "condition" {
+      for_each = var.condition_tags
+      content {
+        test     = "StringEquals"
+        variable = "aws:ResourceTag/${condition.key}"
+        values = [
+          condition.value,
+        ]
+      }
+    }
+  }
 }
 
 # The agent will need to create 3 roles that can only be created after the kubernetes cluster has been created:


### PR DESCRIPTION
of TLS certs trusted by each OIDC provider used with EKS IRSA.

This issue was uncovered today due AWS rotating the us-east-2 regional EKS certificate, signed by a different intermediate root CA with fingeringprint 06B25927C42A721631C1EFD9431E648FA62E1E39 and subject /C=US/O=Amazon/CN=Amazon Root CA 1

ref: https://redpandadata.atlassian.net/browse/CIAINFRA-1150