### PR TITLE
Remove - from prefix within resources

### DIFF
--- a/customer-managed/azure/terraform/routing.tf
+++ b/customer-managed/azure/terraform/routing.tf
@@ -9,7 +9,7 @@ locals {
 
 resource "azurerm_nat_gateway" "redpanda" {
   count                   = local.create_nat
-  name                    = "${var.resource_name_prefix}-ngw-${var.region}"
+  name                    = "${var.resource_name_prefix}ngw-${var.region}"
   location                = var.region
   resource_group_name     = local.redpanda_network_resource_group_name
   sku_name                = "Standard"
@@ -23,7 +23,7 @@ resource "azurerm_nat_gateway" "redpanda" {
 
 resource "azurerm_public_ip_prefix" "redpanda" {
   count               = local.create_nat
-  name                = "${var.resource_name_prefix}-ippre-${var.region}"
+  name                = "${var.resource_name_prefix}ippre-${var.region}"
   location            = var.region
   resource_group_name = local.redpanda_network_resource_group_name
   prefix_length       = 31 # 2 IPs should offer more than enough source ports: 128k


### PR DESCRIPTION
We have a number of inconsistencies as sometimes we include the `-` and sometimes we don't. Our path forward is to remove them. 