### PR TITLE
Add iam:CreateServiceLinkedRole permission for AWS BYOVPC

### DIFF
--- a/customer-managed/aws/terraform/iam_redpanda_agent.tf
+++ b/customer-managed/aws/terraform/iam_redpanda_agent.tf
@@ -354,6 +354,7 @@ data "aws_iam_policy_document" "redpanda_agent2" {
   statement {
     effect = "Allow"
     actions = [
+      "iam:CreateServiceLinkedRole",
       "iam:GetRole",
       "iam:PassRole",
       "iam:ListAttachedRolePolicies",


### PR DESCRIPTION
This is required for new AWS projects that have never yet hosted an EKS cluster.