### PR TITLE
bugfix: Invalid policy in rpk_user.tf when no subnets are created

### DIFF
--- a/customer-managed/aws/terraform/iam_rpk_user.tf
+++ b/customer-managed/aws/terraform/iam_rpk_user.tf
@@ -57,14 +57,6 @@ data "aws_iam_policy_document" "byovpc_rpk_user_1" {
   statement {
     effect = "Allow"
     actions = [
-      "ec2:DescribeSubnets",
-    ]
-    resources = concat(tolist(aws_subnet.public.*.arn), tolist(aws_subnet.private.*.arn))
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
       "iam:GetPolicy",
       "iam:GetPolicyVersion",
       "iam:ListPolicyVersions",

--- a/customer-managed/aws/terraform/nat.tf
+++ b/customer-managed/aws/terraform/nat.tf
@@ -3,7 +3,7 @@ resource "aws_eip" "nat_gateway" {
 }
 
 resource "aws_internet_gateway" "redpanda" {
-  count  = local.create_vpc ||  var.create_internet_gateway ? 1 : 0
+  count  = local.create_vpc || var.create_internet_gateway ? 1 : 0
   vpc_id = data.aws_vpc.redpanda.id
 }
 


### PR DESCRIPTION
If subnets are created outside of this terraform the rpk_user terraform will fail with the error:

```
╷
│ Error: creating IAM Policy (sarah2-rpk-user-1_20250625121034170500000038): MalformedPolicyDocument: Policy statement must contain resources.
│ 	status code: 400, request id: 652d596c-a573-4706-a99b-74a305003aa6
│
│   with aws_iam_policy.byovpc_rpk_user_1[0],
│   on iam_rpk_user.tf line 401, in resource "aws_iam_policy" "byovpc_rpk_user_1":
│  401: resource "aws_iam_policy" "byovpc_rpk_user_1" {
│
╵
```

Since `ec2:DescribeSubnets` is already included above without any resource contraints we can remove this block.