### PR TITLE
Allow user to create S3 vpc gateway endpoint on pre-existing subnets

### DIFF
--- a/customer-managed/aws/terraform/routing.tf
+++ b/customer-managed/aws/terraform/routing.tf
@@ -2,8 +2,12 @@ resource "aws_route_table" "main" {
   vpc_id = data.aws_vpc.redpanda.id
 }
 
+locals {
+  create_private_subnet_routes = local.create_private_subnets ? true : var.create_private_s3_route
+}
+
 resource "aws_route_table" "private" {
-  count  = local.create_private_subnets ? length(var.private_subnet_cidrs) : 0
+  count  = local.create_private_subnet_routes ? length(local.subnet_ids) : 0
   vpc_id = data.aws_vpc.redpanda.id
 
   tags = merge(
@@ -26,14 +30,14 @@ resource "aws_route_table_association" "public" {
 }
 
 resource "aws_route_table_association" "private" {
-  count          = local.create_private_subnets ? length(var.private_subnet_cidrs) : 0
-  subnet_id      = aws_subnet.private[count.index].id
+  count          = local.create_private_subnet_routes ? length(aws_route_table.private) : 0
+  subnet_id      = local.subnet_ids[count.index]
   route_table_id = aws_route_table.private[count.index].id
 }
 
 # Routes S3 traffic to the local gateway endpoint
 resource "aws_vpc_endpoint_route_table_association" "private_s3" {
-  count           = local.create_private_subnets ? length(var.private_subnet_cidrs) : 0
+  count           = length(aws_route_table.private)
   vpc_endpoint_id = aws_vpc_endpoint.s3.id
   route_table_id  = aws_route_table.private[count.index].id
 }

--- a/customer-managed/aws/terraform/variables.tf
+++ b/customer-managed/aws/terraform/variables.tf
@@ -184,3 +184,13 @@ variable "enable_redpanda_connect" {
   When true grants additional permissions required by Redpanda Connect.
   HELP
 }
+
+variable "create_private_s3_route" {
+  type        = bool
+  default     = false
+  description = <<-HELP
+  Applies only when private_subnet_ids is passed. If private subnets are created externally this variable defaults
+  to skipping creation of a VPC endpoint and route to S3 for private access to S3 buckets. Setting this variable to
+  true will create the VPC endpoint and route to S3 for private access to S3 buckets for the passed private subnet IDs.
+  HELP
+}


### PR DESCRIPTION
Previously if the user passes `private_subnet_ids` the code will never create the s3 vpc gateway endpoint. With this change the variable `create_private_s3_route` can be set to true to create the endpoint on the pre-existing subnets.