### PR TITLE
Add autoscaling:DescribeScalingActivities to cluster_autoscaler_policy

### DIFF
--- a/customer-managed/aws/terraform/iam_utility_node_group.tf
+++ b/customer-managed/aws/terraform/iam_utility_node_group.tf
@@ -6,6 +6,7 @@ data "aws_iam_policy_document" "cluster_autoscaler_policy" {
       # https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonec2autoscaling.html
       "autoscaling:DescribeAutoScalingGroups",
       "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeScalingActivities",
       "autoscaling:DescribeLaunchConfigurations",
       "autoscaling:DescribeTags",
 


### PR DESCRIPTION
This permission does not support resource types. ref: https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonec2autoscaling.html

This permission is needed for proper auto-scaling of nodes.