### PR TITLE
Add perms for autoscaler for eks-managed

### DIFF
--- a/customer-managed/aws/terraform/iam_utility_node_group.tf
+++ b/customer-managed/aws/terraform/iam_utility_node_group.tf
@@ -25,7 +25,8 @@ data "aws_iam_policy_document" "cluster_autoscaler_policy" {
       "eks:DescribeNodegroup"
     ]
     resources = [
-      "arn:aws:eks:*:${local.aws_account_id}:nodegroup/redpanda-*"
+      "arn:aws:eks:*:${local.aws_account_id}:nodegroup/redpanda-*",
+      "arn:aws:eks:*:${local.aws_account_id}:nodegroup/eks-redpanda-*"
     ]
   }
 
@@ -37,6 +38,7 @@ data "aws_iam_policy_document" "cluster_autoscaler_policy" {
     ]
     resources = [
       "arn:aws:autoscaling:${var.region}:${local.aws_account_id}:autoScalingGroup:*:autoScalingGroupName/redpanda-*",
+      "arn:aws:autoscaling:${var.region}:${local.aws_account_id}:autoScalingGroup:*:autoScalingGroupName/eks-redpanda-*"
     ]
     dynamic "condition" {
       for_each = var.condition_tags


### PR DESCRIPTION
When using EKS-managed node pools, the node pool name is prefixed with `eks-`. Adding permissions to scale these resources.