### PR TITLE
feat(azure): add variable to grant caller Storage Blob Data Contributor on management account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 **/.terraform/*
 *.tfstate
 *.tfstate.*
+
+# Redpanda
+.redpanda-agent

--- a/customer-managed/azure/README.md
+++ b/customer-managed/azure/README.md
@@ -277,3 +277,28 @@ rpk cloud byoc azure apply --redpanda-id='$rp_id' --subscription-id='$subscripti
 
 ## Check The Status of Cluster Deployment
 You can go to the [Repanda Cloud UI](https://cloud.redpanda.com) to check the progress of the cluster deployment.
+
+## Grant Your User Storage Access
+
+The management storage account has shared access keys disabled and requires Azure AD authentication. The identity running `rpk apply` must have the **Storage Blob Data Contributor** role on the management storage account.
+
+This can be codified in Terraform by setting `grant_caller_management_storage_access = true` in your `byovnet.auto.tfvars.json`:
+
+```json
+"grant_caller_management_storage_access": true
+```
+
+This grants the identity running `rpk apply` the role automatically. Alternatively, you can assign the role manually:
+
+```shell
+ACCOUNT=$(terraform output -raw management_bucket_storage_account_name)
+RESOURCE_GROUP=$(terraform output -raw redpanda_resource_group_name)
+SCOPE=$(az storage account show --name "$ACCOUNT" --resource-group "$RESOURCE_GROUP" --query id -o tsv)
+
+az role assignment create \
+  --assignee $(az ad signed-in-user show --query id -o tsv) \
+  --role "Storage Blob Data Contributor" \
+  --scope "$SCOPE"
+```
+
+> Note: Azure RBAC propagation can take a few minutes. If you see a 403 error immediately after, wait briefly and retry.

--- a/customer-managed/azure/terraform/role_assignments.tf
+++ b/customer-managed/azure/terraform/role_assignments.tf
@@ -1,9 +1,15 @@
 locals {
   create_role_assignment                = var.create_role_assignment ? 1 : 0
   agent_role_assignment_resource_groups = var.create_role_assignment ? local.resource_groups : {}
-  redpanda_operator_namespace           = "redpanda"
+}
 
-  # aks_oidc_issuer_url = "https://TODO"
+// Allow the caller running Terraform to access management storage blobs
+resource "azurerm_role_assignment" "caller_management_storage_blob_data_contributor" {
+  count = var.grant_caller_management_storage_access ? 1 : 0
+
+  scope                = azurerm_storage_account.management.id
+  principal_id         = data.azurerm_client_config.current.object_id
+  role_definition_name = "Storage Blob Data Contributor"
 }
 
 // Allow storing Redpanda TF state to storage

--- a/customer-managed/azure/terraform/vars.condition.tf
+++ b/customer-managed/azure/terraform/vars.condition.tf
@@ -6,6 +6,17 @@ variable "create_role_assignment" {
   HELP
 }
 
+variable "grant_caller_management_storage_access" {
+  type        = bool
+  default     = false
+  description = <<-HELP
+    If true, grants the caller (the identity running Terraform) the Storage Blob Data
+    Contributor role on the management storage account. Required when running Terraform
+    as a user or service principal, since the storage account has shared access keys
+    disabled and only allows Azure AD authentication.
+  HELP
+}
+
 variable "create_nat" {
   type        = bool
   default     = true


### PR DESCRIPTION
The management storage account has shared access keys disabled, requiring Azure AD auth. Added `grant_caller_management_storage_access` variable to optionally grant the Terraform caller the Storage Blob Data Contributor role, and documented the requirement in the README.

If this is not done, the user gets an error when running rpk apply:
```
unexpected status 403 (403 This request is not authorized to perform this operation using this permission.)
```