### PR TITLE
Minor fixups for aws-hub-egress

### DIFF
--- a/aws-hub-egress/.terraform.lock.hcl
+++ b/aws-hub-egress/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.44.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:+xHWvYNFliL9ukFNIPBdqmOQ15Jtw41TN3Qv0CPxi+g=",
+    "zh:0462747d28f6dcd7b1b723bea9da1600526b7cdcf929ed4be54352d74b0746e6",
+    "zh:0c9b7e7b04050360f609ff5700d8a76227fb4ea84dac92b844d82a2013706705",
+    "zh:2877a6854edf237f9d6c66dc928294cbbcf29d3f52577fb8f232d0cfd11d5c0d",
+    "zh:3347b82e222bbfad326b79c408e53a9252b80c6c762f4dd4f4617583394f0a4e",
+    "zh:33997dbe611b5abf49c87a31f29d8f797c97421f67b71fec8aa688799511b758",
+    "zh:5d5c37375c5e776e6e8f95fb8cbd8009258618b9f51c55551a18adc09ef5814a",
+    "zh:67d6bd61c52ca5f4c37c96a76f6820c9f1902e4b83f89faddf9fd7f17ba0b160",
+    "zh:739588639fa30db7084d6939c2eb9b4dd2d7f58dbb5d5b3b2c4bda2a35dcf521",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a953797142df4245bd8f456b9e78690f501a0fff2f58552db4eb2da409cd99e9",
+    "zh:aeb8d616dd34a9f1c5048ed4cdd6d7692db93cd33a468872618d4cd38c4784aa",
+    "zh:dc8420556aca50658247b097de6734259fc3a6012ff1cf96612fca10b3982f9d",
+    "zh:f9083d6d9fb9cbdcd91e38c92f96e67223ecc7ce6d0986bd5eb8e6d52e9aa02b",
+    "zh:f9418aa1e4d29f9026aa6f521e97d085e000902ea929debbbef61135185e3ad4",
+    "zh:fb2494a6c92118055cfb2c114a4fe5c750946a1b0d6be6bf02ab3e37a091fb8b",
+  ]
+}

--- a/aws-hub-egress/data.tf
+++ b/aws-hub-egress/data.tf
@@ -1,0 +1,11 @@
+# Share the TGW with cluster's AWS account via Resource Access Manager.
+# Skipped when cluster's account is the same as the owning account (RAM rejects self-sharing).
+data "aws_caller_identity" "current" {}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}

--- a/aws-hub-egress/locals.tf
+++ b/aws-hub-egress/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  hub_aws_account_id = (
+    var.hub_aws_account_id != ""
+    ? var.hub_aws_account_id
+    : data.aws_caller_identity.current.account_id
+  )
+  create_ram_share = var.spoke_aws_account_id != local.hub_aws_account_id
+}

--- a/aws-hub-egress/outputs.tf
+++ b/aws-hub-egress/outputs.tf
@@ -9,7 +9,7 @@ output "transit_gateway_arn" {
 }
 
 output "ram_resource_share_arn" {
-  value       = local.share_with_redpanda ? aws_ram_resource_share.tgw[0].arn : null
+  value       = local.create_ram_share ? aws_ram_resource_share.tgw[0].arn : null
   description = "ARN of the RAM share. Redpanda must accept this invitation before attaching. Null when hub and spoke share the same account."
 }
 

--- a/aws-hub-egress/providers.tf
+++ b/aws-hub-egress/providers.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = "~> 1.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -9,4 +10,10 @@ terraform {
 
 provider "aws" {
   region = var.region
+  default_tags {
+    tags = var.default_tags
+  }
+  ignore_tags {
+    key_prefixes = var.ignore_tags
+  }
 }

--- a/aws-hub-egress/tgw.tf
+++ b/aws-hub-egress/tgw.tf
@@ -27,29 +27,21 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "hub" {
   tags = merge(var.default_tags, { Name = "${var.common_prefix}-tgw-attachment" })
 }
 
-# Share the TGW with Redpanda's AWS account via Resource Access Manager.
-# Skipped when Redpanda's account is the same as the owning account (RAM rejects self-sharing).
-data "aws_caller_identity" "current" {}
-
-locals {
-  share_with_redpanda = var.redpanda_aws_account_id != data.aws_caller_identity.current.account_id
-}
-
 resource "aws_ram_resource_share" "tgw" {
-  count                     = local.share_with_redpanda ? 1 : 0
+  count                     = local.create_ram_share ? 1 : 0
   name                      = "${var.common_prefix}-tgw-share"
   allow_external_principals = true
   tags                      = var.default_tags
 }
 
 resource "aws_ram_resource_association" "tgw" {
-  count              = local.share_with_redpanda ? 1 : 0
+  count              = local.create_ram_share ? 1 : 0
   resource_arn       = aws_ec2_transit_gateway.hub.arn
   resource_share_arn = aws_ram_resource_share.tgw[0].arn
 }
 
 resource "aws_ram_principal_association" "redpanda" {
-  count              = local.share_with_redpanda ? 1 : 0
-  principal          = var.redpanda_aws_account_id
+  count              = local.create_ram_share ? 1 : 0
+  principal          = var.spoke_aws_account_id
   resource_share_arn = aws_ram_resource_share.tgw[0].arn
 }

--- a/aws-hub-egress/variables.tf
+++ b/aws-hub-egress/variables.tf
@@ -11,8 +11,8 @@ variable "common_prefix" {
 }
 
 variable "vpc_cidr" {
-  type    = string
-  default = "100.64.0.0/16"
+  type        = string
+  default     = "100.64.0.0/16"
   description = <<-HELP
   CIDR for the hub/egress VPC.
   MUST NOT overlap with any spoke VPC CIDRs — TGW routing breaks silently when CIDRs
@@ -35,8 +35,8 @@ variable "private_subnet_cidrs" {
 }
 
 variable "spoke_cidrs" {
-  type = list(string)
-  default = ["10.0.0.0/16"]
+  type        = list(string)
+  default     = ["10.0.0.0/16"]
   description = <<-HELP
   CIDRs of all spoke VPCs that will attach to this TGW.
   Used to install return routes in the hub's public subnet so NAT Gateway replies
@@ -48,12 +48,17 @@ variable "spoke_cidrs" {
   HELP
 }
 
-variable "redpanda_aws_account_id" {
+variable "hub_aws_account_id" {
   type        = string
-  default     = "472797112831"
   description = <<-HELP
-  Redpanda's AWS account ID. The TGW will be shared with this account via RAM so
-  Redpanda can attach the BYOC spoke VPC to it.
+  AWS account ID where the transit gateway will be created.
+  HELP
+}
+
+variable "spoke_aws_account_id" {
+  type        = string
+  description = <<-HELP
+  AWS account id where the redpanda cluster will be created.
   HELP
 }
 
@@ -61,4 +66,12 @@ variable "default_tags" {
   type        = map(string)
   default     = {}
   description = "Tags applied to all resources."
+}
+
+variable "ignore_tags" {
+  type        = list(string)
+  default     = []
+  description = <<-HELP
+  List of tag keys that will be ignored during reconciliation of this terraform
+  HELP
 }

--- a/aws-hub-egress/vpc.tf
+++ b/aws-hub-egress/vpc.tf
@@ -1,11 +1,3 @@
-data "aws_availability_zones" "available" {
-  state = "available"
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "hub" {
   cidr_block           = var.vpc_cidr
   enable_dns_support   = true


### PR DESCRIPTION
Renamed account variables to make it more clear that both are in the customer accounts, one is a hub and one is a spoke.