### PR TITLE
Do not require spoke_aws_account_id

### DIFF
--- a/aws-hub-egress/locals.tf
+++ b/aws-hub-egress/locals.tf
@@ -4,5 +4,10 @@ locals {
     ? var.hub_aws_account_id
     : data.aws_caller_identity.current.account_id
   )
-  create_ram_share = var.spoke_aws_account_id != local.hub_aws_account_id
+  spoke_aws_account_id = (
+    var.spoke_aws_account_id != ""
+    ? var.spoke_aws_account_id
+    : local.hub_aws_account_id
+  )
+  create_ram_share = local.spoke_aws_account_id != local.hub_aws_account_id
 }

--- a/aws-hub-egress/tgw.tf
+++ b/aws-hub-egress/tgw.tf
@@ -42,6 +42,6 @@ resource "aws_ram_resource_association" "tgw" {
 
 resource "aws_ram_principal_association" "redpanda" {
   count              = local.create_ram_share ? 1 : 0
-  principal          = var.spoke_aws_account_id
+  principal          = local.spoke_aws_account_id
   resource_share_arn = aws_ram_resource_share.tgw[0].arn
 }

--- a/aws-hub-egress/variables.tf
+++ b/aws-hub-egress/variables.tf
@@ -57,6 +57,7 @@ variable "hub_aws_account_id" {
 
 variable "spoke_aws_account_id" {
   type        = string
+  default     = ""
   description = <<-HELP
   AWS account id where the redpanda cluster will be created.
   HELP


### PR DESCRIPTION
If spoke_aws_account_id is not provided, use hub_aws_account_id, in which case no ram share will be created.