### PR TITLE
Add GCP Hub Egress, Centralized NAT via VPC Network Peering

### DIFF
--- a/gcp-hub-egress/README.md
+++ b/gcp-hub-egress/README.md
@@ -1,0 +1,132 @@
+# GCP Hub Egress — Centralized NAT via VPC Network Peering
+
+This Terraform module provisions a **hub/egress VPC** in your GCP project and wires it to one or more Redpanda BYOC clusters through GCP VPC Network Peering with custom route export.  All internet-bound traffic from the Redpanda cluster exits through a **NAT gateway VM** (running in a size-1 MIG for automatic restart) in the hub VPC — the Redpanda cluster's VPC never needs its own Cloud NAT, Cloud Router, or NAT VM.
+
+## Architecture
+
+```
+┌──────────────────────────────────┐         ┌──────────────────────────────────────┐
+│  Hub / Egress Project            │         │  Redpanda BYOC Project (spoke)       │
+│                                  │         │                                      │
+│  ┌────────────────────────────┐  │         │  ┌──────────────────────────────┐    │
+│  │  Hub VPC                   │  │         │  │  Redpanda VPC                │    │
+│  │  100.64.0.0/20 (default)   │  │         │  │  (your CIDR, e.g. 10.0.0.0/16)    │
+│  │                            │  │ Peering │  │                              │    │
+│  │  NAT VM (MIG/1) ◄──────────┼──┼─────────┼──┼── nodes (no public IPs)      │    │
+│  │  │  export_custom_routes   │  │         │  │  import_custom_routes=true   │    │
+│  │  └──► Internet             │  │         │  │  (no Cloud Router / NAT)     │    │
+│  └────────────────────────────┘  │         │  └──────────────────────────────┘    │
+└──────────────────────────────────┘         └──────────────────────────────────────┘
+```
+
+**What this Terraform creates:**
+- A hub VPC with a single regional subnet
+- Two custom static routes:
+  - `0.0.0.0/0 → default-internet-gateway` tagged for the NAT VM only (so the NAT VM can reach the internet directly, priority 100)
+  - `0.0.0.0/0 → NAT VM internal IP` untagged at priority 900 — this is the route exported via peering to the Redpanda spoke VPC (`next_hop_ip` routes are exportable; `next_hop_gateway` routes are not)
+- A NAT gateway VM (Debian, IP forwarding + iptables masquerade) running in a size-1 MIG with a reserved static internal IP (so the exported route remains valid across MIG instance replacements) and a reserved static public IP
+- VPC Network Peerings from hub → each Redpanda VPC with `export_custom_routes = true`, one per entry in `redpanda_vpcs`
+
+**What the Redpanda platform does (on your behalf):**
+- Creates the cluster VPC without a Cloud Router or Cloud NAT, and without a local default route
+- Creates the reciprocal VPC Network Peering from Redpanda VPC → hub VPC with `import_custom_routes = true`
+- The imported `0.0.0.0/0 → NAT VM internal IP` route directs all internet traffic through the hub
+
+> **Note on GCP routing:** Local static routes always beat imported peering routes regardless of priority. The Redpanda spoke VPC must not have its own local `0.0.0.0/0` route — if one exists, it will silently win and traffic will not flow through the hub.
+
+## Prerequisites
+
+- Terraform ≥ 1.0
+- GCP credentials for the **hub project** (the account that will own the hub VPC)
+- If the hub and Redpanda cluster are in **different GCP projects**, the hub project's compute service account must have `roles/compute.networkPeer` in the Redpanda project (or broader network admin rights) so that the peering can be created
+
+## Usage
+
+### 1. Create the hub infrastructure
+
+The Redpanda VPC name follows the pattern `redpanda-<network_id>` and is visible in the Redpanda Cloud console before cluster creation. You can populate `redpanda_vpcs` on the first apply alongside the hub infrastructure.
+
+```hcl
+# terraform.tfvars
+project         = "my-hub-project"
+region          = "us-central1"
+hub_subnet_cidr = "100.64.0.0/20"   # must not overlap with Redpanda VPC CIDR
+
+redpanda_vpcs = {
+  "cluster-a" = { vpc_name = "redpanda-abc123", project = "my-redpanda-project" }
+  "cluster-b" = { vpc_name = "redpanda-def456" }   # project defaults to var.project
+}
+```
+
+```bash
+terraform init
+terraform apply
+```
+
+Note the outputs:
+
+```
+hub_vpc_name   = "hub-vpc"
+hub_project_id = "my-hub-project"
+nat_public_ip  = "34.x.x.x"
+```
+
+### 2. Create the Redpanda BYOC cluster
+
+When creating your Redpanda BYOC cluster, pass the hub VPC details so that Redpanda skips Cloud Router/NAT creation and imports the default route from the hub.
+
+The Redpanda provisioner will:
+1. Create the cluster VPC without a Cloud Router or Cloud NAT, and without a local default route
+2. Create a VPC Network Peering from the Redpanda VPC to the hub VPC with `import_custom_routes = true`
+3. The imported `0.0.0.0/0` route directs all internet-bound traffic through the hub NAT VM
+
+### 3. Add additional clusters
+
+To peer more Redpanda cluster VPCs with the hub, add entries to `redpanda_vpcs` and re-apply. The module uses `for_each` over this map, so no module modifications are needed:
+
+```hcl
+redpanda_vpcs = {
+  "cluster-a" = { vpc_name = "redpanda-abc123", project = "my-redpanda-project" }
+  "cluster-b" = { vpc_name = "redpanda-def456" }
+  "cluster-c" = { vpc_name = "redpanda-ghi789" }   # newly added
+}
+```
+
+## Variables
+
+| Name | Default | Description |
+|------|---------|-------------|
+| `project` | (required) | GCP project ID for the hub VPC and NAT gateway VM |
+| `region` | (required) | GCP region for all resources |
+| `zone` | `""` | GCP zone for the NAT gateway MIG. Defaults to the first available zone in `region` |
+| `routing_mode` | `REGIONAL` | VPC routing mode |
+| `common_prefix` | `hub` | Prefix applied to all resource names |
+| `hub_subnet_cidr` | `100.64.0.0/20` | Hub subnet CIDR. Must not overlap any Redpanda VPC CIDR |
+| `redpanda_vpcs` | `{}` | Map of Redpanda BYOC cluster VPCs to peer with the hub. See variable description for shape |
+| `nat_machine_type` | `e2-micro` | Machine type for the NAT gateway VM. Size up for higher egress throughput |
+| `nat_image` | `debian-cloud/debian-13` | Boot image for the NAT gateway VM |
+| `nat_disk_size_gb` | `10` | Boot disk size (GB) for the NAT gateway VM |
+| `nat_source_ranges` | RFC-1918 + CGNAT | Source CIDRs allowed to reach the NAT VM for forwarding. Narrow to spoke CIDRs for tighter control |
+| `labels` | `{}` | Labels applied to all resources that support labeling (VM, reserved IPs) |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `hub_vpc_name` | Hub VPC network name — pass to Redpanda at cluster creation time |
+| `hub_vpc_self_link` | Full self-link URL of the hub VPC |
+| `hub_project_id` | GCP project ID of the hub VPC |
+| `hub_subnet_name` | Name of the hub subnet |
+| `nat_public_ip` | Public IP all Redpanda egress traffic appears from |
+
+## Important notes
+
+**Custom route export requires `next_hop_ip`.** GCP's VPC Network Peering only exports *custom* routes, and only those with `next_hop_ip` or `next_hop_instance` — routes with `next_hop_gateway = "default-internet-gateway"` are never exported. This module uses a reserved static internal IP for the NAT VM and exports a `0.0.0.0/0 → NAT internal IP` route. A separate tagged route (`nat-direct`) with `next_hop_gateway` is used only by the NAT VM itself so it can reach the internet directly.
+
+**CIDR overlap.** `hub_subnet_cidr` must not overlap the Redpanda cluster VPC CIDR. GCP will reject the peering if CIDRs overlap. The default `100.64.0.0/20` (CGNAT range) avoids common enterprise ranges.
+
+**Multiple clusters.** VPC Network Peering is point-to-point. The module supports multiple Redpanda clusters via `for_each` over `redpanda_vpcs` — add an entry per cluster, no module changes needed.
+
+**Cross-project peering.** When hub and Redpanda VPCs are in different GCP projects, the principal running Terraform for this module needs `roles/compute.networkPeer` (or equivalent) in the Redpanda project so GCP allows creating the peering from the hub side.
+
+**NAT throughput.** The NAT VM funnels all internet egress for peered clusters through a single instance. `e2-micro` is shared-core with a low per-VM egress bandwidth cap. Set `nat_machine_type` to a larger type if the NAT becomes a throughput bottleneck.

--- a/gcp-hub-egress/locals.tf
+++ b/gcp-hub-egress/locals.tf
@@ -1,0 +1,17 @@
+data "google_compute_zones" "available" {
+  project = var.project
+  region  = var.region
+}
+
+locals {
+  zone = var.zone != "" ? var.zone : data.google_compute_zones.available.names[0]
+
+  # Resolve each entry's project, defaulting to var.project when not set.
+  redpanda_vpcs = {
+    for k, v in var.redpanda_vpcs : k => {
+      vpc_name  = v.vpc_name
+      project   = v.project != "" ? v.project : var.project
+      self_link = "projects/${v.project != "" ? v.project : var.project}/global/networks/${v.vpc_name}"
+    }
+  }
+}

--- a/gcp-hub-egress/nat.tf
+++ b/gcp-hub-egress/nat.tf
@@ -1,0 +1,86 @@
+resource "google_compute_address" "nat" {
+  project = var.project
+  region  = var.region
+  name    = "${var.common_prefix}-nat-ip"
+}
+
+# Reserved internal IP so the spoke-to-nat route (next_hop_ip) stays valid
+# across MIG instance replacements.
+resource "google_compute_address" "nat_internal" {
+  project      = var.project
+  region       = var.region
+  name         = "${var.common_prefix}-nat-internal-ip"
+  address_type = "INTERNAL"
+  subnetwork   = google_compute_subnetwork.hub.self_link
+}
+
+resource "google_compute_instance_template" "nat" {
+  project        = var.project
+  region         = var.region
+  name_prefix    = "${var.common_prefix}-nat-"
+  machine_type   = var.nat_machine_type
+  can_ip_forward = true
+  tags           = ["nat-direct"]
+
+  disk {
+    source_image = var.nat_image
+    auto_delete  = true
+    boot         = true
+    disk_size_gb = var.nat_disk_size_gb
+    disk_type    = "pd-balanced"
+  }
+
+  network_interface {
+    network    = google_compute_network.hub.self_link
+    subnetwork = google_compute_subnetwork.hub.self_link
+    network_ip = google_compute_address.nat_internal.address
+    access_config {
+      nat_ip = google_compute_address.nat.address
+    }
+  }
+
+  metadata_startup_script = <<-SCRIPT
+    #!/bin/bash
+    set -e
+    sysctl -w net.ipv4.ip_forward=1
+    echo 'net.ipv4.ip_forward = 1' > /etc/sysctl.d/99-ip-forward.conf
+    EXT_IF=$(ip route get 8.8.8.8 | awk '{for(i=1;i<=NF;i++) if($i=="dev") print $(i+1)}' | head -1)
+    iptables -t nat -A POSTROUTING -o "$EXT_IF" -j MASQUERADE
+    iptables -A FORWARD -i "$EXT_IF" -m state --state RELATED,ESTABLISHED -j ACCEPT
+    iptables -A FORWARD -j ACCEPT
+    apt-get update -qq && apt-get install -y -qq iptables-persistent
+    netfilter-persistent save
+  SCRIPT
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# MIG of size 1: auto-restarts the NAT VM if the instance crashes or is terminated.
+resource "google_compute_instance_group_manager" "nat" {
+  project            = var.project
+  zone               = local.zone
+  name               = "${var.common_prefix}-nat-mig"
+  base_instance_name = "${var.common_prefix}-nat"
+  target_size        = 1
+
+  version {
+    instance_template = google_compute_instance_template.nat.self_link
+  }
+}
+
+# Allow RFC-1918 + CGNAT traffic to reach the NAT VM for forwarding.
+# GCP firewall evaluates ingress rules against the destination VM for IP-forwarded packets.
+resource "google_compute_firewall" "nat_forwarding" {
+  project = var.project
+  name    = "${var.common_prefix}-allow-nat-forward"
+  network = google_compute_network.hub.name
+
+  allow { protocol = "tcp" }
+  allow { protocol = "udp" }
+  allow { protocol = "icmp" }
+
+  source_ranges = var.nat_source_ranges
+  target_tags   = ["nat-direct"]
+}

--- a/gcp-hub-egress/outputs.tf
+++ b/gcp-hub-egress/outputs.tf
@@ -1,0 +1,24 @@
+output "hub_vpc_name" {
+  value       = google_compute_network.hub.name
+  description = "Hub VPC network name. Pass this to Redpanda when creating the cluster."
+}
+
+output "hub_vpc_self_link" {
+  value       = google_compute_network.hub.self_link
+  description = "Full self-link URL of the hub VPC."
+}
+
+output "hub_project_id" {
+  value       = var.project
+  description = "GCP project ID of the hub VPC. Required by Redpanda for cross-project peering."
+}
+
+output "hub_subnet_name" {
+  value       = google_compute_subnetwork.hub.name
+  description = "Name of the hub subnet."
+}
+
+output "nat_public_ip" {
+  value       = google_compute_address.nat.address
+  description = "Public IP address all Redpanda egress traffic will appear from."
+}

--- a/gcp-hub-egress/peering.tf
+++ b/gcp-hub-egress/peering.tf
@@ -1,0 +1,15 @@
+resource "google_compute_network_peering" "hub_to_redpanda" {
+  for_each = local.redpanda_vpcs
+
+  name         = "${var.common_prefix}-to-${each.key}"
+  network      = google_compute_network.hub.self_link
+  peer_network = each.value.self_link
+
+  # Advertise the custom default internet route (0.0.0.0/0) into the Redpanda VPC
+  # so that all internet-bound traffic from Redpanda nodes exits via this hub's NAT.
+  export_custom_routes = true
+  import_custom_routes = false
+
+  export_subnet_routes_with_public_ip = false
+  import_subnet_routes_with_public_ip = false
+}

--- a/gcp-hub-egress/providers.tf
+++ b/gcp-hub-egress/providers.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = "~> 1.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project        = var.project
+  region         = var.region
+  default_labels = var.labels
+}

--- a/gcp-hub-egress/variables.tf
+++ b/gcp-hub-egress/variables.tf
@@ -1,0 +1,95 @@
+variable "project" {
+  type        = string
+  description = "GCP project ID where the hub VPC and Cloud NAT will be created."
+}
+
+variable "region" {
+  type        = string
+  description = "GCP region for all resources."
+}
+
+variable "zone" {
+  type        = string
+  default     = ""
+  description = "GCP zone for the NAT gateway VM. Defaults to the first available zone in var.region."
+}
+
+variable "nat_machine_type" {
+  type        = string
+  default     = "e2-micro"
+  description = "Machine type for the NAT gateway VM. Larger types get higher egress bandwidth caps; size up if the NAT becomes a throughput bottleneck."
+}
+
+variable "nat_image" {
+  type        = string
+  default     = "debian-cloud/debian-13"
+  description = "Boot image for the NAT gateway VM."
+}
+
+variable "nat_disk_size_gb" {
+  type        = number
+  default     = 10
+  description = "Boot disk size (GB) for the NAT gateway VM."
+}
+
+variable "nat_source_ranges" {
+  type        = list(string)
+  default     = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "100.64.0.0/10"]
+  description = "Source CIDRs allowed to reach the NAT gateway for forwarding. Defaults to all RFC-1918 + CGNAT; narrow this to your Redpanda spoke VPC CIDR(s) for tighter ingress control."
+}
+
+variable "labels" {
+  type        = map(string)
+  default     = {}
+  description = "Labels applied to all resources that support labeling (e.g. team, cost-center, environment)."
+}
+
+variable "routing_mode" {
+  type        = string
+  default     = "REGIONAL"
+  description = "VPC routing mode"
+}
+
+variable "common_prefix" {
+  type        = string
+  default     = "hub"
+  description = "Prefix applied to all resource names."
+}
+
+variable "hub_subnet_cidr" {
+  type        = string
+  default     = "100.64.0.0/20"
+  description = <<-HELP
+  CIDR for the hub/egress subnet.
+  Must not overlap with the Redpanda cluster VPC CIDR — VPC peering is rejected
+  when CIDRs overlap and routing will break silently if they collide after the fact.
+  100.64.0.0/20 (CGNAT range) is a safe default: it is not routable on the public
+  internet and is unlikely to conflict with spoke VPC CIDRs.
+  HELP
+}
+
+variable "redpanda_vpcs" {
+  type = map(object({
+    vpc_name = string
+    project  = optional(string, "")
+  }))
+  default = {
+  }
+  description = <<-HELP
+  Map of Redpanda BYOC cluster VPCs to peer with the hub. The map key is used as
+  the peering name suffix (e.g. "cluster-1" → "$${common_prefix}-to-cluster-1").
+
+  The VPC name follows the pattern "redpanda-<network_id>" and is known before
+  cluster creation — it can be derived from the network ID visible in the Redpanda
+  Cloud console before running "rpk byoc apply". This means entries can be added
+  here on the first terraform apply, alongside the hub infrastructure.
+
+  project defaults to var.project when omitted or empty.
+
+  Example:
+    redpanda_vpcs = {
+      "cluster-a" = { vpc_name = "redpanda-abc123", project = "my-gcp-project" }
+      "cluster-b" = { vpc_name = "redpanda-def456" }
+    }
+  HELP
+}

--- a/gcp-hub-egress/vpc.tf
+++ b/gcp-hub-egress/vpc.tf
@@ -1,0 +1,48 @@
+resource "google_compute_network" "hub" {
+  project                         = var.project
+  name                            = "${var.common_prefix}-vpc"
+  auto_create_subnetworks         = false
+  routing_mode                    = var.routing_mode
+  delete_default_routes_on_create = true
+}
+
+resource "google_compute_subnetwork" "hub" {
+  project       = var.project
+  region        = var.region
+  name          = "${var.common_prefix}-subnet"
+  network       = google_compute_network.hub.id
+  ip_cidr_range = var.hub_subnet_cidr
+}
+
+# Tagged route: only the NAT VM (tag "nat-direct") uses this to reach the internet.
+# Priority 100 ensures this beats the untagged spoke-to-nat route below, preventing
+# the NAT VM from routing its own egress back to itself.
+resource "google_compute_route" "nat_to_internet" {
+  project          = var.project
+  name             = "${var.common_prefix}-nat-to-internet"
+  network          = google_compute_network.hub.name
+  dest_range       = "0.0.0.0/0"
+  next_hop_gateway = "default-internet-gateway"
+  tags             = ["nat-direct"]
+  priority         = 100
+}
+
+# Untagged route: next_hop_instance routes ARE exportable via VPC peering (unlike
+# next_hop_gateway = "default-internet-gateway" which GCP never exports).
+# Priority 900 so the imported copy in the Redpanda spoke VPC wins against the
+# spoke's own system default route (priority 1000).
+#
+# CRITICAL: GCP's routing rule is that LOCAL static routes always beat IMPORTED
+# peering routes regardless of priority. The Redpanda spoke VPC MUST be created
+# with delete_default_routes_on_create = true so it has no local 0.0.0.0/0 route.
+# If a local default route exists, it will always win over this imported route
+# and no traffic will flow through hub-nat. To remove an existing default route:
+# gcloud compute routes delete <default-route-name> --network=<redpanda-vpc>
+resource "google_compute_route" "spoke_to_nat" {
+  project     = var.project
+  name        = "${var.common_prefix}-spoke-to-nat"
+  network     = google_compute_network.hub.name
+  dest_range  = "0.0.0.0/0"
+  next_hop_ip = google_compute_address.nat_internal.address
+  priority    = 900
+}


### PR DESCRIPTION
Add GCP Hub Egress at cloud examples. 