### PR TITLE
Make Azure tiered storage objects private

### DIFF
--- a/customer-managed/azure/terraform/storage.tf
+++ b/customer-managed/azure/terraform/storage.tf
@@ -55,10 +55,11 @@ resource "azurerm_storage_account" "tiered_storage" {
   is_hns_enabled           = true
   access_tier              = "Hot"
 
-  # WARNING/FIXME: Disabling public access breaks Terraform
-  # and the Azure Portal.
+  # WARNING/FIXME: Disabling public network access breaks Terraform
+  # and the Azure Portal, so public_network_access_enabled stays true.
+  # Anonymous blob access is still denied via allow_nested_items_to_be_public.
   public_network_access_enabled     = true
-  allow_nested_items_to_be_public   = true
+  allow_nested_items_to_be_public   = false
   cross_tenant_replication_enabled  = false
   shared_access_key_enabled         = false
   infrastructure_encryption_enabled = true


### PR DESCRIPTION
## What

Set `allow_nested_items_to_be_public = false` on the `tiered_storage` storage account (it was `true`), mirroring the byovnet module change in redpanda-data/terraform-azure-redpanda-byovnet#8. `public_network_access_enabled` is left unchanged (`true`).

## Why — closes the remaining Snyk finding

Follow-up to #81, which made the **management** bucket private (closing Snyk **SNYK-CC-00600**). The second finding, **SNYK-CC-00602** ("Public read access is enabled for storage containers and blobs"), still fired on the `tiered_storage` account. This clears it. Snyk IaC scan after the change reports **0 high-severity issues**.

## Parity with standard BYOC

This matches how standard (non-BYOVPC) BYOC Azure clusters already configure tiered storage: `allow_nested_items_to_be_public = false`, private container, `shared_access_key_enabled = false`, `default_to_oauth_authentication = true`, with brokers authenticating via **Entra ID workload identity** (role *Storage Blob Data Contributor*) — never anonymous reads or shared keys. Denying anonymous object access has no functional impact; BYOVPC was the outlier that still allowed it.

## Testing

Validated with the BYOVPC Azure certification suite (cloudv2 cert harness pinned to the byovnet tiered-storage commit):

**https://buildkite.com/redpanda/cloudv2-certifications/builds/17554**

All Azure BYOC CMR variants (base, private-link, Iceberg) provision, run, and tear down cleanly with tiered storage exercised — clusters fully functional with anonymous object access disabled.
